### PR TITLE
tests: add VM integration test for ota-update image A/B slot updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shell-escape",
+ "strum",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "shell-escape",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2097,6 +2098,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +340,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +426,41 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "data-encoding"
@@ -427,6 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -448,6 +511,12 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -807,12 +876,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -825,6 +900,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -950,6 +1031,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,12 +1169,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -1368,6 +1491,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1393,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1660,6 +1784,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1961,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +2056,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.2.0",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2277,7 +2476,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2386,7 +2585,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -2722,10 +2921,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,10 +1358,12 @@ name = "ota-update"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "bootspec",
  "cachix-client",
  "clap",
+ "fs2",
  "regex",
  "reqwest",
  "serde",
@@ -2686,6 +2698,28 @@ checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -8,9 +8,11 @@ version = "0.0.1"
 
 [dependencies]
 anyhow = "1.0.100"
+async-trait = "*"
 axum = "*"
 bootspec = "*"
 clap = { version = "4.5.54", features = ["derive", "env"] }
+fs2 = "*" # For locking
 regex = "*"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.149"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_with = "*"
 shell-escape = "*"
+strum = { version = "0.27", features = ["derive"] }
 thiserror = "*"
 tokio = { version = "1.49", features = [
   "rt-multi-thread",

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 serde_json = "1.0.149"
 serde = { version = "1.0.202", features = ["derive"] }
+serde_with = "*"
 thiserror = "*"
 tokio = { version = "1.49", features = [
   "rt-multi-thread",

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 serde_json = "1.0.149"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_with = "*"
+shell-escape = "*"
 thiserror = "*"
 tokio = { version = "1.49", features = [
   "rt-multi-thread",

--- a/crates/ota-update/src/bin/ota-update.rs
+++ b/crates/ota-update/src/bin/ota-update.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use cachix_client::{CachixClientConfig, nixos::filter_valid_systems};
 use clap::{ArgAction, Parser, Subcommand};
 use ota_update::cli::{CachixOptions, QueryUpdates, query_updates};
+use ota_update::image::cli::ImageUpdate;
 use ota_update::profile;
 use ota_update::query::query_available_updates;
 use regex::Regex;
@@ -46,6 +47,7 @@ enum Commands {
     Query(QueryUpdates),
 
     Cachix(CachixOptions),
+    Image(ImageUpdate),
 }
 
 async fn get_generations() -> anyhow::Result<()> {
@@ -203,6 +205,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             cachix_host,
             cache,
         }) => perform_cachix_update(&pin_name, token, cachix_host, cache).await?,
+        Commands::Image(image) => image.handle().await?,
     }
     Ok(())
 }

--- a/crates/ota-update/src/bootctl.rs
+++ b/crates/ota-update/src/bootctl.rs
@@ -16,10 +16,10 @@ pub struct BootctlItem {
     pub show_title: String,
     pub sort_key: String,
     pub version: String,
-    pub machine_id: String,
+    pub machine_id: Option<String>,
     pub options: String,
     pub linux: PathBuf,
-    pub initrd: Vec<PathBuf>,
+    pub initrd: Option<Vec<PathBuf>>,
     pub is_reported: bool,
     pub is_default: bool,
     pub is_selected: bool,
@@ -52,29 +52,31 @@ pub async fn get_bootctl_info() -> anyhow::Result<BootctlInfo> {
         .code()
         .context("bootctl crashed/killed by signal")?
     {
-        0 => {
-            // Design defence:
-            // we have our struct matching only NixOS boot records, so filter out all with sort_key != "nixos" before deserializing
-            // otherwise entries from memtest, dual boot, whatever else break deserializing.
-            let info: Vec<serde_json::Value> =
-                serde_json::from_slice(&output.stdout).context("Parsing bootctl output")?;
-            let info = info
-                .into_iter()
-                .filter(|item| {
-                    item.get("sortKey")
-                        .is_some_and(|val| val.as_str() == Some("nixos"))
-                })
-                .collect();
-            let info =
-                serde_json::from_value(info).context("While decoding bootctl json output")?;
-            Ok(info)
-        }
+        0 => parse_bootctl(&output.stdout),
         // Special case: if bootctl fails with mentioning `--esp-path` in error output, then we are in testing VM without EFI, handle it and return empty list
         _ if err.contains("--esp-path") => Ok(Vec::new()),
         code => Err(anyhow::anyhow!(
             "bootctl failed with exit code {code}, and stderr output: {err}"
         )),
     }
+}
+
+// Pure parser, for test data injection
+pub fn parse_bootctl(json: impl AsRef<[u8]>) -> anyhow::Result<BootctlInfo> {
+    // Design defence:
+    // we have our struct matching only NixOS boot records, so filter out all with sort_key != "nixos" before deserializing
+    // otherwise entries from memtest, dual boot, whatever else break deserializing.
+    let info: Vec<serde_json::Value> =
+        serde_json::from_slice(json.as_ref()).context("Parsing bootctl output")?;
+    let info = info
+        .into_iter()
+        .filter(|item| {
+            item.get("sortKey")
+                .is_some_and(|val| val.as_str() == Some("nixos"))
+        })
+        .collect();
+    let info = serde_json::from_value(info).context("While decoding bootctl json output")?;
+    Ok(info)
 }
 
 pub fn find_init(boot_info: &BootctlItem) -> Option<&Path> {

--- a/crates/ota-update/src/bootctl.rs
+++ b/crates/ota-update/src/bootctl.rs
@@ -61,7 +61,9 @@ pub async fn get_bootctl_info() -> anyhow::Result<BootctlInfo> {
     }
 }
 
-// Pure parser, for test data injection
+/// Pure parser, for test data injection
+/// # Errors
+/// * Throw out JSON parsing error
 pub fn parse_bootctl(json: impl AsRef<[u8]>) -> anyhow::Result<BootctlInfo> {
     // Design defence:
     // we have our struct matching only NixOS boot records, so filter out all with sort_key != "nixos" before deserializing

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -5,7 +5,7 @@ use super::plan::Plan;
 use super::runtime::Runtime;
 use crate::bootctl::get_bootctl_info;
 use anyhow::{Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
@@ -13,7 +13,7 @@ use tokio::fs::read_to_string;
 use tokio::process::Command;
 
 struct UpdateLock {
-    file: File,
+    _file: File,
     path: PathBuf,
 }
 
@@ -137,7 +137,7 @@ impl UpdateLock {
         file.try_lock_exclusive()
             .context("another ota-update instance is already running")?;
 
-        Ok(Self { file, path })
+        Ok(Self { _file: file, path })
     }
 }
 

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -46,6 +46,7 @@ pub enum ImageAction {
         #[arg(long)]
         hash: Option<String>,
     },
+    Status,
 }
 
 impl ImageUpdate {
@@ -69,6 +70,11 @@ impl ImageUpdate {
                 let plan = Plan::remove(&rt, &version)?;
 
                 execute_plan(plan, self.dry_run).await
+            }
+            ImageAction::Status => {
+                let status = rt.inspect()?;
+                println!("{status}");
+                Ok(())
             }
         }
     }

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -86,7 +86,7 @@ async fn populate_runtime() -> anyhow::Result<Runtime> {
         .context("while reading /proc/cmdline")?;
     let bootctl = get_bootctl_info().await?;
     let lvs = read_lvs_output().await.context("while read lvs")?;
-    Ok(Runtime::new(&lvs, &cmdline, &bootctl))
+    Ok(Runtime::new(&lvs, &cmdline, &bootctl)?)
 }
 
 async fn execute_plan(plan: Plan, dry_run: bool) -> anyhow::Result<()> {

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -1,3 +1,4 @@
+use super::Version;
 use super::executor::{DryRunExecutor, Executor, ShellExecutor};
 use super::manifest::Manifest;
 use super::plan::Plan;
@@ -64,7 +65,8 @@ impl ImageUpdate {
             }
 
             ImageAction::Remove { version, hash } => {
-                let plan = Plan::remove(&rt, &version, hash.as_deref())?;
+                let version = Version::new(version, hash);
+                let plan = Plan::remove(&rt, &version)?;
 
                 execute_plan(plan, self.dry_run).await
             }

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -1,0 +1,143 @@
+use super::executor::{DryRunExecutor, Executor, ShellExecutor};
+use super::manifest::Manifest;
+use super::plan::Plan;
+use super::runtime::Runtime;
+use crate::bootctl::get_bootctl_info;
+use anyhow::{Context, Result};
+use clap::{Args, Parser, Subcommand};
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use tokio::fs::read_to_string;
+use tokio::process::Command;
+
+struct UpdateLock {
+    file: File,
+    path: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+pub struct ImageUpdate {
+    #[command(subcommand)]
+    pub action: ImageAction,
+
+    /// Do not execute commands, only print what would be done
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ImageAction {
+    /// Install image from manifest
+    Install {
+        /// Path to manifest.json
+        #[arg(long)]
+        manifest: String,
+    },
+
+    /// Remove installed image slot
+    Remove {
+        /// Version to remove
+        #[arg(long)]
+        version: String,
+
+        /// Optional hash fragment
+        #[arg(long)]
+        hash: Option<String>,
+    },
+}
+
+impl ImageUpdate {
+    pub async fn handle(self) -> anyhow::Result<()> {
+        let rt = populate_runtime().await?;
+        match self.action {
+            ImageAction::Install { manifest } => {
+                let manifest_path = Path::new(&manifest);
+                let source_dir = manifest_path
+                    .parent()
+                    .ok_or_else(|| anyhow::anyhow!("manifest path has no parent directory"))?;
+
+                let manifest = Manifest::from_file(manifest_path)?;
+                let plan = Plan::install(&rt, &manifest, &source_dir)?;
+
+                execute_plan(plan, self.dry_run).await
+            }
+
+            ImageAction::Remove { version, hash } => {
+                let plan = Plan::remove(&rt, &version, hash.as_deref())?;
+
+                execute_plan(plan, self.dry_run).await
+            }
+        }
+    }
+}
+
+async fn populate_runtime() -> anyhow::Result<Runtime> {
+    let cmdline = read_to_string("/proc/cmdline")
+        .await
+        .context("while reading /proc/cmdline")?;
+    let bootctl = get_bootctl_info().await?;
+    let lvs = read_lvs_output().await.context("while read lvs")?;
+    Ok(Runtime::new(&lvs, &cmdline, &bootctl))
+}
+
+async fn execute_plan(plan: Plan, dry_run: bool) -> anyhow::Result<()> {
+    if plan.steps.is_empty() {
+        println!("Nothing to do.");
+        return Ok(());
+    }
+
+    // Acquire global lock
+    let _lock = UpdateLock::acquire("/run/ota-update.lock")?;
+
+    if dry_run {
+        let exec = DryRunExecutor;
+        exec.run_plan(&plan).await?;
+    } else {
+        let exec = ShellExecutor::default();
+        exec.run_plan(&plan).await?;
+    }
+
+    Ok(())
+}
+
+async fn read_lvs_output() -> Result<String> {
+    let output = Command::new("lvs")
+        .args(["--all", "--nameprefixes", "--noheadings"])
+        .output()
+        .await
+        .context("failed to execute lvs")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("lvs failed: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+impl UpdateLock {
+    fn acquire<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("opening lock file {:?}", path))?;
+
+        file.try_lock_exclusive()
+            .context("another ota-update instance is already running")?;
+
+        Ok(Self { file, path })
+    }
+}
+
+impl Drop for UpdateLock {
+    fn drop(&mut self) {
+        // Best-effort cleanup:
+        // - lock is released automatically when File is dropped
+        // - remove the file itself
+        let _ = std::fs::remove_file(&self.path);
+    }
+}

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -50,6 +50,7 @@ pub enum ImageAction {
 }
 
 impl ImageUpdate {
+    #[allow(clippy::missing_errors_doc)]
     pub async fn handle(self) -> anyhow::Result<()> {
         let rt = populate_runtime().await?;
         match self.action {
@@ -60,7 +61,7 @@ impl ImageUpdate {
                     .context("manifest path has no parent directory")?;
 
                 let manifest = Manifest::from_file(manifest_path)?;
-                let plan = Plan::install(&rt, &manifest, &source_dir)?;
+                let plan = Plan::install(&rt, &manifest, source_dir)?;
 
                 execute_plan(plan, self.dry_run).await
             }
@@ -86,7 +87,7 @@ async fn populate_runtime() -> anyhow::Result<Runtime> {
         .context("while reading /proc/cmdline")?;
     let bootctl = get_bootctl_info().await?;
     let lvs = read_lvs_output().await.context("while invoking lvs")?;
-    Ok(Runtime::new(lvs, &cmdline, bootctl)?)
+    Runtime::new(lvs, &cmdline, bootctl)
 }
 
 async fn execute_plan(plan: Plan, dry_run: bool) -> anyhow::Result<()> {
@@ -114,10 +115,11 @@ impl UpdateLock {
         let path = path.as_ref().to_path_buf();
         let file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .read(true)
             .write(true)
             .open(&path)
-            .with_context(|| format!("opening lock file {:?}", path))?;
+            .with_context(|| format!("opening lock file {}", path.display()))?;
 
         file.try_lock_exclusive()
             .context("another ota-update instance is already running")?;

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -57,7 +57,7 @@ impl ImageUpdate {
                 let manifest_path = Path::new(&manifest);
                 let source_dir = manifest_path
                     .parent()
-                    .ok_or_else(|| anyhow::anyhow!("manifest path has no parent directory"))?;
+                    .context("manifest path has no parent directory")?;
 
                 let manifest = Manifest::from_file(manifest_path)?;
                 let plan = Plan::install(&rt, &manifest, &source_dir)?;

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -72,7 +72,7 @@ impl ImageUpdate {
                 execute_plan(plan, self.dry_run).await
             }
             ImageAction::Status => {
-                let status = rt.inspect()?;
+                let status = rt.inspect();
                 println!("{status}");
                 Ok(())
             }

--- a/crates/ota-update/src/image/cli.rs
+++ b/crates/ota-update/src/image/cli.rs
@@ -86,7 +86,7 @@ async fn populate_runtime() -> anyhow::Result<Runtime> {
         .context("while reading /proc/cmdline")?;
     let bootctl = get_bootctl_info().await?;
     let lvs = read_lvs_output().await.context("while read lvs")?;
-    Ok(Runtime::new(&lvs, &cmdline, &bootctl)?)
+    Ok(Runtime::new(&lvs, &cmdline, bootctl)?)
 }
 
 async fn execute_plan(plan: Plan, dry_run: bool) -> anyhow::Result<()> {

--- a/crates/ota-update/src/image/executor.rs
+++ b/crates/ota-update/src/image/executor.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::process::Stdio;
+use tokio::process::Command;
+
+use super::pipeline::Pipeline;
+use super::plan::Plan;
+
+#[async_trait]
+pub trait Executor {
+    async fn run_pipeline(&self, pipeline: &Pipeline) -> Result<()>;
+
+    async fn run_plan(&self, plan: &Plan) -> Result<()> {
+        for pipeline in &plan.steps {
+            self.run_pipeline(&pipeline).await?;
+        }
+        Ok(())
+    }
+}
+
+pub struct DryRunExecutor;
+
+#[async_trait]
+impl Executor for DryRunExecutor {
+    async fn run_pipeline(&self, pipeline: &Pipeline) -> Result<()> {
+        println!("DRY-RUN: {}", pipeline.format_shell());
+        Ok(())
+    }
+}
+
+pub struct ShellExecutor {
+    pub shell: String,
+}
+
+impl Default for ShellExecutor {
+    fn default() -> Self {
+        Self {
+            shell: "/bin/sh".into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Executor for ShellExecutor {
+    async fn run_pipeline(&self, pipeline: &Pipeline) -> Result<()> {
+        let cmdline = pipeline.format_shell();
+
+        let status = Command::new(&self.shell)
+            .arg("-c")
+            .arg(&cmdline)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .await?;
+
+        if !status.success() {
+            anyhow::bail!(
+                "pipeline failed (exit={}): {}",
+                status.code().unwrap_or(-1),
+                cmdline
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ota-update/src/image/executor.rs
+++ b/crates/ota-update/src/image/executor.rs
@@ -7,12 +7,12 @@ use super::pipeline::Pipeline;
 use super::plan::Plan;
 
 #[async_trait]
-pub trait Executor {
+pub(crate) trait Executor {
     async fn run_pipeline(&self, pipeline: &Pipeline) -> Result<()>;
 
     async fn run_plan(&self, plan: &Plan) -> Result<()> {
         for pipeline in &plan.steps {
-            self.run_pipeline(&pipeline).await?;
+            self.run_pipeline(pipeline).await?;
         }
         Ok(())
     }

--- a/crates/ota-update/src/image/group.rs
+++ b/crates/ota-update/src/image/group.rs
@@ -1,6 +1,7 @@
 use super::lvm::Volume;
 use super::runtime::{KernelParams, Runtime};
 use super::slot::{Kind, Slot, SlotClass};
+use super::uki::UkiEntry;
 use anyhow::{Result, bail};
 use std::collections::HashMap;
 
@@ -20,18 +21,37 @@ impl VolumeSlot {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SlotGroup {
     pub version: Option<String>,
     pub hash: Option<String>,
     pub root: Option<Volume>,
     pub verity: Option<Volume>,
+    pub uki: Option<UkiEntry>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 struct SlotKey {
     version: Option<String>,
     hash: Option<String>,
+}
+
+impl From<&UkiEntry> for SlotKey {
+    fn from(uki: &UkiEntry) -> Self {
+        Self {
+            version: Some(uki.version.clone()),
+            hash: Some(uki.hash.clone()),
+        }
+    }
+}
+
+impl SlotGroup {
+    fn key(&self) -> SlotKey {
+        SlotKey {
+            version: self.version.clone(),
+            hash: self.hash.clone(),
+        }
+    }
 }
 
 pub fn group_volumes(volumes: &Vec<Volume>) -> Result<Vec<SlotGroup>> {
@@ -53,6 +73,7 @@ pub fn group_volumes(volumes: &Vec<Volume>) -> Result<Vec<SlotGroup>> {
             hash: slot.hash.clone(),
             root: None,
             verity: None,
+            uki: None,
         });
 
         match slot.kind {
@@ -62,6 +83,48 @@ pub fn group_volumes(volumes: &Vec<Volume>) -> Result<Vec<SlotGroup>> {
     }
 
     Ok(map.into_values().collect())
+}
+
+pub fn group_uki(mut slot_groups: Vec<SlotGroup>, ukis: Vec<UkiEntry>) -> Result<Vec<SlotGroup>> {
+    let mut uki_map: HashMap<SlotKey, UkiEntry> = HashMap::new();
+
+    for uki in ukis {
+        let key = SlotKey::from(&uki);
+        if uki_map.insert(key, uki.clone()).is_some() {
+            bail!(
+                "invalid state: multiple UKIs for version={} hash={}",
+                uki.version,
+                uki.hash
+            );
+        }
+    }
+
+    for slot in &mut slot_groups {
+        // legacy slot — no UKI
+        if slot.is_legacy() {
+            continue;
+        }
+
+        if slot.is_empty() {
+            continue; // empty slot
+        };
+
+        if let Some(uki) = uki_map.remove(&slot.key()) {
+            slot.uki = Some(uki);
+        }
+    }
+
+    for uki in uki_map.into_values() {
+        slot_groups.push(SlotGroup {
+            version: Some(uki.version.clone()),
+            hash: Some(uki.hash.clone()),
+            root: None,
+            verity: None,
+            uki: Some(uki),
+        })
+    }
+
+    Ok(slot_groups)
 }
 
 impl SlotGroup {
@@ -154,6 +217,7 @@ mod tests {
             hash: Some("abcdabcdabcdabcd".into()),
             root: Some(vol("root_1.2.3_abcdabcdabcdabcd")),
             verity: Some(vol("verity_1.2.3_abcdabcdabcdabcd")),
+            uki: None,
         };
 
         assert!(g.validate().is_ok());
@@ -166,6 +230,7 @@ mod tests {
             hash: Some("deadbeefdeadbeef".into()),
             root: None,
             verity: None,
+            uki: None,
         };
 
         assert!(g.validate().is_ok());
@@ -178,6 +243,7 @@ mod tests {
             hash: Some("abcdabcdabcdabcd".into()),
             root: Some(vol("root_1.2.3_abcdabcdabcdabcd")),
             verity: None,
+            uki: None,
         };
 
         let err = g.validate().unwrap_err();
@@ -191,6 +257,7 @@ mod tests {
             hash: None,
             root: Some(vol("root_1.2.3")),
             verity: Some(vol("verity_1.2.3")),
+            uki: None,
         };
 
         let err = g.validate().unwrap_err();
@@ -209,6 +276,7 @@ mod active_tests {
             hash: Some("deadbeefdeadbeef".into()),
             root: None,
             verity: None,
+            uki: None,
         };
 
         let kernel = KernelParams {
@@ -226,6 +294,7 @@ mod active_tests {
             hash: Some("abcdabcdabcdabcd".into()),
             root: None,
             verity: None,
+            uki: None,
         };
 
         let kernel = KernelParams {
@@ -243,6 +312,7 @@ mod active_tests {
             hash: Some("deadbeefdeadbeef".into()),
             root: None,
             verity: None,
+            uki: None,
         };
 
         let kernel = KernelParams {
@@ -251,5 +321,96 @@ mod active_tests {
         };
 
         assert!(slot.is_active(&kernel));
+    }
+}
+
+#[cfg(test)]
+mod uki_tests {
+    use super::*;
+
+    fn slot(version: Option<&str>, hash: Option<&str>) -> SlotGroup {
+        SlotGroup {
+            version: version.map(str::to_string),
+            hash: hash.map(str::to_string),
+            root: None,
+            verity: None,
+            uki: None,
+        }
+    }
+
+    fn legacy_slot() -> SlotGroup {
+        SlotGroup {
+            version: Some("0".into()),
+            hash: None,
+            root: None,
+            verity: None,
+            uki: None,
+        }
+    }
+
+    fn uki(version: &str, hash: &str) -> UkiEntry {
+        UkiEntry {
+            version: version.into(),
+            hash: hash.into(),
+            boot_counter: None,
+        }
+    }
+
+    #[test]
+    fn uki_is_attached_to_matching_slot() {
+        let slots = vec![slot(Some("1.2.3"), Some("deadbeefdeadbeef"))];
+
+        let ukis = vec![uki("1.2.3", "deadbeefdeadbeef")];
+
+        let result = group_uki(slots, ukis).expect("grouping must succeed");
+
+        assert_eq!(result.len(), 1);
+        let slot = &result[0];
+        assert!(slot.uki.is_some());
+        assert_eq!(slot.uki.as_ref().unwrap().hash, "deadbeefdeadbeef");
+    }
+
+    #[test]
+    fn legacy_slot_does_not_receive_uki() {
+        let slots = vec![legacy_slot()];
+
+        let ukis = vec![uki("0", "deadbeefdeadbeef")];
+
+        let result = group_uki(slots, ukis).expect("grouping must succeed");
+
+        assert_eq!(result.len(), 2);
+
+        let legacy = result.iter().find(|s| s.is_legacy()).unwrap();
+        assert!(legacy.uki.is_none());
+
+        let uki_slot = result.iter().find(|s| s.uki.is_some()).unwrap();
+        assert_eq!(uki_slot.version.as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn orphan_uki_creates_new_slot_group() {
+        let slots = vec![];
+
+        let ukis = vec![uki("2.0.0", "cafebabecafebabe")];
+
+        let result = group_uki(slots, ukis).expect("grouping must succeed");
+
+        assert_eq!(result.len(), 1);
+        let slot = &result[0];
+        assert_eq!(slot.version.as_deref(), Some("2.0.0"));
+        assert_eq!(slot.hash.as_deref(), Some("cafebabecafebabe"));
+        assert!(slot.uki.is_some());
+    }
+
+    #[test]
+    fn empty_slot_is_ignored() {
+        let slots = vec![slot(None, None)];
+
+        let ukis = vec![uki("1.2.3", "deadbeefdeadbeef")];
+
+        let result = group_uki(slots, ukis).expect("grouping must succeed");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.iter().filter(|s| s.uki.is_some()).count(), 1);
     }
 }

--- a/crates/ota-update/src/image/group.rs
+++ b/crates/ota-update/src/image/group.rs
@@ -243,21 +243,7 @@ impl SlotGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    pub fn volume(name: &str) -> Volume {
-        Volume {
-            lv_name: name.to_string(),
-            vg_name: "vg".into(),
-            lv_attr: None,
-            lv_size_bytes: None,
-        }
-    }
-
-    pub fn slots(names: &[&str]) -> Vec<Slot> {
-        let vols: Vec<_> = names.iter().map(|n| volume(n)).collect();
-        let (slots, _unparsed) = Slot::from_volumes(vols);
-        slots
-    }
+    use crate::image::test::slots;
 
     #[test]
     fn group_root_and_verity_same_version() {

--- a/crates/ota-update/src/image/group.rs
+++ b/crates/ota-update/src/image/group.rs
@@ -26,6 +26,7 @@ impl SlotGroup {
 }
 
 impl SlotGroup {
+    // NOTE: This algoritm intentionally avoid HashMap/HashSet, because we have only 2-3 slot pairs.
     pub fn group_volumes(
         slots: Vec<Slot>,
         boots: Vec<BootEntry>,
@@ -100,18 +101,17 @@ impl SlotGroup {
     #[must_use]
     pub fn version(&self) -> Option<&Version> {
         if let Some(root) = &self.root {
-            return root.version();
-        }
-        if let Some(verity) = &self.verity {
-            return verity.version();
-        }
-        if let Some(boot) = &self.boot {
+            root.version()
+        } else if let Some(verity) = &self.verity {
+            verity.version()
+        } else if let Some(boot) = &self.boot {
             // UKI always represents a used slot
             // Version is reconstructed only for comparison / display
             // (no leaking into internal logic)
-            return boot.version();
+            boot.version()
+        } else {
+            None
         }
-        None
     }
 
     /// Returns empty identifier for this group, if it is an empty slot.

--- a/crates/ota-update/src/image/group.rs
+++ b/crates/ota-update/src/image/group.rs
@@ -1,0 +1,255 @@
+use super::lvm::Volume;
+use super::runtime::{KernelParams, Runtime};
+use super::slot::{Kind, Slot, SlotClass};
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct VolumeSlot {
+    pub volume: Volume,
+    pub slot: Slot,
+}
+
+impl VolumeSlot {
+    pub fn try_from_volume(volume: &Volume) -> Result<Self> {
+        let slot = Slot::try_from(volume.lv_name.as_str())?;
+        Ok(Self {
+            volume: volume.clone(),
+            slot,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct SlotGroup {
+    pub version: Option<String>,
+    pub hash: Option<String>,
+    pub root: Option<Volume>,
+    pub verity: Option<Volume>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct SlotKey {
+    version: Option<String>,
+    hash: Option<String>,
+}
+
+pub fn group_volumes(volumes: &Vec<Volume>) -> Result<Vec<SlotGroup>> {
+    let mut map: HashMap<SlotKey, SlotGroup> = HashMap::new();
+
+    for volume in volumes {
+        let VolumeSlot { volume, slot } = match VolumeSlot::try_from_volume(volume) {
+            Ok(slot) => slot,
+            Err(_) => continue, // Ignore non-slot volumes
+        };
+
+        let key = SlotKey {
+            version: slot.version.clone(),
+            hash: slot.hash.clone(),
+        };
+
+        let entry = map.entry(key).or_insert_with(|| SlotGroup {
+            version: slot.version.clone(),
+            hash: slot.hash.clone(),
+            root: None,
+            verity: None,
+        });
+
+        match slot.kind {
+            Kind::Root => entry.root = Some(volume),
+            Kind::Verity => entry.verity = Some(volume),
+        }
+    }
+
+    Ok(map.into_values().collect())
+}
+
+impl SlotGroup {
+    pub fn is_empty(&self) -> bool {
+        self.version.is_none()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.root.is_some() && self.verity.is_some()
+    }
+
+    pub fn is_legacy(&self) -> bool {
+        matches!(self.version.as_deref(), Some("0"))
+    }
+
+    pub fn is_active(&self, kernel: &KernelParams) -> bool {
+        // Legacy case
+        if self.is_legacy() && kernel.store_hash.is_none() {
+            return true;
+        }
+
+        // Normal case
+        match (
+            &self.version,
+            &self.hash,
+            kernel.revision.as_deref(),
+            kernel.verity_hash_fragment(),
+        ) {
+            (Some(v), Some(h), Some(kv), Some(kh)) => v == kv && h == kh,
+            _ => false,
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        // Root / Verity must be present together
+        match (&self.root, &self.verity) {
+            (Some(_), Some(_)) => {}
+            (None, None) => {}
+            _ => bail!("incomplete slot: root and verity must be present together"),
+        }
+
+        // If version is set, hash must be set
+        if self.version.is_some() && self.hash.is_none() {
+            bail!("invalid slot: version is set but hash is missing");
+        }
+
+        Ok(())
+    }
+
+    /// Classify slot state based on runtime kernel parameters.
+    pub fn classify(&self, kernel: &KernelParams) -> SlotClass {
+        // Structural validation always comes first
+        if self.validate().is_err() {
+            return SlotClass::Broken;
+        }
+
+        // Active slot (includes legacy-active case)
+        if self.is_active(kernel) {
+            return SlotClass::Active;
+        }
+
+        // Empty but valid slot
+        if self.version.is_none() {
+            return SlotClass::Empty;
+        }
+
+        // Installed but not active
+        SlotClass::Inactive
+    }
+}
+
+#[cfg(test)]
+fn vol(name: &str) -> Volume {
+    Volume {
+        lv_name: name.to_string(),
+        vg_name: "vg".into(),
+        lv_attr: None,
+        lv_size_bytes: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_full_slot() {
+        let g = SlotGroup {
+            version: Some("1.2.3".into()),
+            hash: Some("abcdabcdabcdabcd".into()),
+            root: Some(vol("root_1.2.3_abcdabcdabcdabcd")),
+            verity: Some(vol("verity_1.2.3_abcdabcdabcdabcd")),
+        };
+
+        assert!(g.validate().is_ok());
+    }
+
+    #[test]
+    fn empty_slot_with_hash_is_valid() {
+        let g = SlotGroup {
+            version: None,
+            hash: Some("deadbeefdeadbeef".into()),
+            root: None,
+            verity: None,
+        };
+
+        assert!(g.validate().is_ok());
+    }
+
+    #[test]
+    fn incomplete_pair_is_invalid() {
+        let g = SlotGroup {
+            version: Some("1.2.3".into()),
+            hash: Some("abcdabcdabcdabcd".into()),
+            root: Some(vol("root_1.2.3_abcdabcdabcdabcd")),
+            verity: None,
+        };
+
+        let err = g.validate().unwrap_err();
+        assert!(err.to_string().contains("incomplete slot"));
+    }
+
+    #[test]
+    fn version_without_hash_is_invalid() {
+        let g = SlotGroup {
+            version: Some("1.2.3".into()),
+            hash: None,
+            root: Some(vol("root_1.2.3")),
+            verity: Some(vol("verity_1.2.3")),
+        };
+
+        let err = g.validate().unwrap_err();
+        assert!(err.to_string().contains("hash is missing"));
+    }
+}
+
+#[cfg(test)]
+mod active_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_slot_is_active_when_no_store_hash() {
+        let slot = SlotGroup {
+            version: Some("0".into()),
+            hash: Some("deadbeefdeadbeef".into()),
+            root: None,
+            verity: None,
+        };
+
+        let kernel = KernelParams {
+            store_hash: None,
+            revision: None,
+        };
+
+        assert!(slot.is_active(&kernel));
+    }
+
+    #[test]
+    fn normal_slot_active() {
+        let slot = SlotGroup {
+            version: Some("1.2.3".into()),
+            hash: Some("abcdabcdabcdabcd".into()),
+            root: None,
+            verity: None,
+        };
+
+        let kernel = KernelParams {
+            revision: Some("1.2.3".into()),
+            store_hash: Some("abcdabcdabcdabcdffffffff".into()),
+        };
+
+        assert!(slot.is_active(&kernel));
+    }
+
+    #[test]
+    fn legacy_slot_is_active_when_no_store_hash_present() {
+        let slot = SlotGroup {
+            version: Some("0".into()),
+            hash: Some("deadbeefdeadbeef".into()),
+            root: None,
+            verity: None,
+        };
+
+        let kernel = KernelParams {
+            revision: None,
+            store_hash: None,
+        };
+
+        assert!(slot.is_active(&kernel));
+    }
+}

--- a/crates/ota-update/src/image/group.rs
+++ b/crates/ota-update/src/image/group.rs
@@ -1,10 +1,7 @@
 use super::Version;
-use super::lvm::Volume;
-use super::runtime::{KernelParams, Runtime};
+use super::runtime::KernelParams;
 use super::slot::{Kind, Slot, SlotClass};
 use super::uki::BootEntry;
-use anyhow::{Result, bail};
-use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct SlotGroup {
@@ -184,7 +181,7 @@ impl SlotGroup {
 
             // Legacy fallback:
             // kernel has no version info, only USED legacy slot is active
-            (Some(slot_v), None) => self.is_legacy(),
+            (Some(_), None) => self.is_legacy(),
 
             // Empty slots are never active
             _ => false,

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -34,7 +34,7 @@ impl Volume {
     #[must_use]
     pub fn device_file(&self) -> PathBuf {
         let mut path = PathBuf::from("/dev/mapper");
-        path.push(&format!("{}-{}", self.vg_name, self.lv_name));
+        path.push(format!("{}-{}", self.vg_name, self.lv_name));
         path
     }
 
@@ -69,7 +69,7 @@ pub(crate) fn parse_lvs_json(input: impl AsRef<[u8]>) -> Result<Vec<Volume>> {
     Ok(parsed.report.into_iter().flat_map(|r| r.lv).collect())
 }
 
-pub async fn read_lvs_output() -> Result<Vec<Volume>> {
+pub(crate) async fn read_lvs_output() -> Result<Vec<Volume>> {
     let output = Command::new("lvs")
         .args([
             "--all",

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -1,9 +1,8 @@
-use super::slot::{Kind, Slot};
 use anyhow::{Result, anyhow};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Volume {
+pub struct Volume {
     pub lv_name: String,
     pub vg_name: String,
     pub lv_attr: Option<String>,

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -3,11 +3,11 @@ use anyhow::{Result, anyhow};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq)]
-struct Volume {
-    lv_name: String,
-    vg_name: String,
-    lv_attr: Option<String>,
-    lv_size_bytes: Option<u64>,
+pub(crate) struct Volume {
+    pub lv_name: String,
+    pub vg_name: String,
+    pub lv_attr: Option<String>,
+    pub lv_size_bytes: Option<u64>,
 }
 
 fn parse_lv_size(value: &str) -> Result<u64> {
@@ -81,7 +81,7 @@ fn parse_lvs_line(line: &str) -> Result<HashMap<String, String>> {
     Ok(map)
 }
 
-fn parse_lvs_output(output: &str) -> Vec<Volume> {
+pub(crate) fn parse_lvs_output(output: &str) -> Vec<Volume> {
     output
         .lines()
         .filter_map(|line| {

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -1,0 +1,162 @@
+use super::slot::Slot;
+use anyhow::{Result, anyhow};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+struct Volume {
+    lv_name: String,
+    vg_name: String,
+    lv_attr: Option<String>,
+    lv_size_bytes: Option<u64>,
+}
+
+fn parse_lv_size(value: &str) -> Result<u64> {
+    if value.is_empty() {
+        return Err(anyhow!("empty LV size"));
+    }
+
+    let value = value.trim();
+    let (number, unit) = value.split_at(value.len() - 1);
+
+    let multiplier = match unit.to_ascii_lowercase().as_str() {
+        "k" => 1024_u64,
+        "m" => 1024_u64.pow(2),
+        "g" => 1024_u64.pow(3),
+        "t" => 1024_u64.pow(4),
+        _ => return Err(anyhow!("unknown size unit: {unit}")),
+    };
+
+    let number = number.replace(',', ".");
+    let number: f64 = number
+        .parse()
+        .map_err(|_| anyhow!("invalid size number: {number}"))?;
+
+    Ok((number * multiplier as f64) as u64)
+}
+
+fn volume_from_map(fields: &HashMap<String, String>) -> Result<Volume> {
+    let lv_name = fields
+        .get("LVM2_LV_NAME")
+        .ok_or_else(|| anyhow!("missing LV name"))?
+        .to_string();
+
+    let vg_name = fields
+        .get("LVM2_VG_NAME")
+        .ok_or_else(|| anyhow!("missing VG name"))?
+        .to_string();
+
+    let lv_attr = fields.get("LVM2_LV_ATTR").cloned();
+
+    let lv_size_bytes = fields
+        .get("LVM2_LV_SIZE")
+        .filter(|s| !s.is_empty())
+        .map(|s| parse_lv_size(s))
+        .transpose()?;
+
+    Ok(Volume {
+        lv_name,
+        vg_name,
+        lv_attr,
+        lv_size_bytes,
+    })
+}
+
+fn parse_lvs_line(line: &str) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+
+    for token in line.split_whitespace() {
+        let (key, raw_value) = token
+            .split_once('=')
+            .ok_or_else(|| anyhow!("invalid token: {token}"))?;
+
+        // ожидаем значение в одинарных кавычках
+        let value = raw_value
+            .strip_prefix('\'')
+            .and_then(|v| v.strip_suffix('\''))
+            .ok_or_else(|| anyhow!("invalid quoted value: {raw_value}"))?;
+
+        map.insert(key.to_string(), value.to_string());
+    }
+
+    Ok(map)
+}
+
+fn parse_lvs_output(output: &str) -> Vec<Volume> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+
+            let fields = parse_lvs_line(line).ok()?;
+            volume_from_map(&fields).ok()
+        })
+        .collect()
+}
+
+fn slots_from_volumes(volumes: &[Volume], vg_name: &str) -> Vec<Slot> {
+    volumes
+        .iter()
+        .filter(|v| v.vg_name == vg_name)
+        .filter_map(|v| Slot::try_from(v.lv_name.as_str()).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lv_size_gb() {
+        let size = parse_lv_size("32,00g").unwrap();
+        assert_eq!(size, 32 * 1024_u64.pow(3));
+    }
+
+    #[test]
+    fn parse_lv_size_fractional() {
+        let size = parse_lv_size("1,50g").unwrap();
+        assert_eq!(size, (1.5 * 1024_f64.powi(3)) as u64);
+    }
+
+    #[test]
+    fn parse_lvs_line_basic() {
+        let line = "LVM2_LV_NAME='fast'  LVM2_VG_NAME='vg0'   LVM2_LV_SIZE='1,00g'";
+        let map = parse_lvs_line(line).unwrap();
+
+        assert_eq!(map["LVM2_LV_NAME"], "fast");
+        assert_eq!(map["LVM2_VG_NAME"], "vg0");
+        assert_eq!(map["LVM2_LV_SIZE"], "1,00g");
+    }
+
+    #[test]
+    fn volume_from_map_ok() {
+        let mut map = HashMap::new();
+        map.insert("LVM2_LV_NAME".into(), "fast".into());
+        map.insert("LVM2_VG_NAME".into(), "vg0".into());
+        map.insert("LVM2_LV_SIZE".into(), "2,00g".into());
+
+        let vol = volume_from_map(&map).unwrap();
+        assert_eq!(vol.lv_name, "fast");
+        assert_eq!(vol.vg_name, "vg0");
+        assert_eq!(vol.lv_size_bytes, Some(2 * 1024_u64.pow(3)));
+    }
+
+    #[test]
+    fn parse_lvs_output_and_slots() {
+        let output = r#"
+          LVM2_LV_NAME='root_1.2.3_deadbeef' LVM2_VG_NAME='vg0' LVM2_LV_SIZE='10,00g'
+          LVM2_LV_NAME='swap' LVM2_VG_NAME='vg0' LVM2_LV_SIZE='2,00g'
+          LVM2_LV_NAME='root_empty' LVM2_VG_NAME='vg1' LVM2_LV_SIZE='5,00g'
+        "#;
+
+        let volumes = parse_lvs_output(output);
+        assert_eq!(volumes.len(), 3);
+
+        let slots = slots_from_volumes(&volumes, "vg0");
+        assert_eq!(slots.len(), 1);
+        assert_eq!(slots[0].name, "root");
+        assert_eq!(slots[0].version.as_deref(), Some("1.2.3"));
+    }
+}

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -96,14 +96,6 @@ pub(crate) fn parse_lvs_output(output: &str) -> Vec<Volume> {
         .collect()
 }
 
-fn slots_from_volumes(volumes: &[Volume], vg_name: &str) -> Vec<Slot> {
-    volumes
-        .iter()
-        .filter(|v| v.vg_name == vg_name)
-        .filter_map(|v| Slot::try_from(v.lv_name.as_str()).ok())
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -99,6 +99,7 @@ pub(crate) fn parse_lvs_output(output: &str) -> Vec<Volume> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::image::Version;
 
     #[test]
     fn parse_lv_size_gb() {
@@ -146,9 +147,12 @@ mod tests {
         let volumes = parse_lvs_output(output);
         assert_eq!(volumes.len(), 3);
 
-        let slots = slots_from_volumes(&volumes, "vg0");
-        assert_eq!(slots.len(), 1);
-        assert_eq!(slots[0].kind, Kind::Root);
-        assert_eq!(slots[0].version.as_deref(), Some("1.2.3"));
+        let (slots, _) = Slot::from_volumes(volumes);
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].kind(), Kind::Root);
+        assert_eq!(
+            slots[0].version().as_deref(),
+            Some(&Version::new("1.2.3".into(), Some("deadbeef".into())))
+        );
     }
 }

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -99,6 +99,7 @@ pub(crate) fn parse_lvs_output(output: &str) -> Vec<Volume> {
 mod tests {
     use super::*;
     use crate::image::Version;
+    use crate::image::slot::{Kind, Slot};
 
     #[test]
     fn parse_lv_size_gb() {

--- a/crates/ota-update/src/image/lvm.rs
+++ b/crates/ota-update/src/image/lvm.rs
@@ -1,4 +1,4 @@
-use super::slot::Slot;
+use super::slot::{Kind, Slot};
 use anyhow::{Result, anyhow};
 use std::collections::HashMap;
 
@@ -156,7 +156,7 @@ mod tests {
 
         let slots = slots_from_volumes(&volumes, "vg0");
         assert_eq!(slots.len(), 1);
-        assert_eq!(slots[0].name, "root");
+        assert_eq!(slots[0].kind, Kind::Root);
         assert_eq!(slots[0].version.as_deref(), Some("1.2.3"));
     }
 }

--- a/crates/ota-update/src/image/manifest.rs
+++ b/crates/ota-update/src/image/manifest.rs
@@ -5,34 +5,34 @@ use anyhow::Context;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
-struct File {
-    name: String,
-    sha256sum: String,
+pub struct File {
+    pub name: String,
+    pub sha256sum: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct Manifest {
-    meta: HashMap<String, String>,
-    version: String,
-    verity_root_hash: String,
-    kernel: File,
-    store: File,
-    verity: File,
+pub struct Manifest {
+    pub meta: HashMap<String, String>,
+    pub version: String,
+    pub verity_root_hash: String,
+    pub kernel: File,
+    pub store: File,
+    pub verity: File,
 }
 
 impl Manifest {
-    fn from_file(filename: &Path) -> anyhow::Result<Self> {
+    pub fn from_file(filename: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(filename).context("Read manifest")?;
         let this = serde_json::from_str(&content).context("Deserializing manifest)")?;
         Ok(this)
     }
 
-    fn hash_fragment(&self) -> &str {
+    pub fn hash_fragment(&self) -> &str {
         &self.verity_root_hash[..16]
     }
 
     // Validate, if all files mentioned in manifest exists (and have matching hash)
-    fn validate(&self, base_dir: &Path, checksum: bool) -> anyhow::Result<()> {
+    pub fn validate(&self, base_dir: &Path, checksum: bool) -> anyhow::Result<()> {
         self.kernel
             .validate(base_dir, checksum)
             .context("while validating kernel")?;

--- a/crates/ota-update/src/image/manifest.rs
+++ b/crates/ota-update/src/image/manifest.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use serde::Deserialize;
 
+use super::Version;
+
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct File {
     #[serde(rename = "file")]
@@ -32,6 +34,10 @@ impl Manifest {
 
     pub fn hash_fragment(&self) -> &str {
         &self.root_verity_hash[..16]
+    }
+
+    pub fn to_version(&self) -> Version {
+        Version::new(self.version.clone(), Some(self.hash_fragment().to_string()))
     }
 
     // Validate, if all files mentioned in manifest exists (and have matching hash)

--- a/crates/ota-update/src/image/manifest.rs
+++ b/crates/ota-update/src/image/manifest.rs
@@ -26,22 +26,25 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn from_file(filename: &Path) -> anyhow::Result<Self> {
+    pub(crate) fn from_file(filename: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(filename).context("Read manifest")?;
         let this = serde_json::from_str(&content).context("Deserializing manifest)")?;
         Ok(this)
     }
 
+    #[must_use]
     pub fn hash_fragment(&self) -> &str {
         &self.root_verity_hash[..16]
     }
 
+    #[must_use]
     pub fn to_version(&self) -> Version {
         Version::new(self.version.clone(), Some(self.hash_fragment().to_string()))
     }
 
     // Validate, if all files mentioned in manifest exists (and have matching hash)
-    pub fn validate(&self, base_dir: &Path, checksum: bool) -> anyhow::Result<()> {
+    #[allow(dead_code)] // FIXME: validation would be used later
+    pub(crate) fn validate(&self, base_dir: &Path, checksum: bool) -> anyhow::Result<()> {
         self.kernel
             .validate(base_dir, checksum)
             .context("while validating kernel")?;
@@ -56,14 +59,19 @@ impl Manifest {
 }
 
 impl File {
+    #[must_use]
     pub fn full_name<P: AsRef<Path>>(&self, base_dir: P) -> PathBuf {
         base_dir.as_ref().join(&self.name)
     }
 
+    #[must_use]
     pub fn is_compressed(&self) -> bool {
-        self.name.ends_with(".zst")
+        std::path::Path::new(&self.name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
     }
 
+    #[allow(dead_code)]
     fn validate(&self, base_dir: &Path, _checksum: bool) -> anyhow::Result<()> {
         let full_name = self.full_name(base_dir);
         if !std::fs::exists(&full_name)? {

--- a/crates/ota-update/src/image/manifest.rs
+++ b/crates/ota-update/src/image/manifest.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct File {
+    name: String,
+    sha256sum: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    meta: HashMap<String, String>,
+    version: String,
+    verity_root_hash: String,
+    kernel: File,
+    store: File,
+    verity: File,
+}
+
+impl Manifest {
+    fn from_file(filename: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(filename).context("Read manifest")?;
+        let this = serde_json::from_str(&content).context("Deserializing manifest)")?;
+        Ok(this)
+    }
+
+    fn hash_fragment(&self) -> &str {
+        &self.verity_root_hash[..16]
+    }
+
+    // Validate, if all files mentioned in manifest exists (and have matching hash)
+    fn validate(&self, base_dir: &Path, checksum: bool) -> anyhow::Result<()> {
+        self.kernel
+            .validate(base_dir, checksum)
+            .context("while validating kernel")?;
+        self.store
+            .validate(base_dir, checksum)
+            .context("while validating store image")?;
+        self.verity
+            .validate(base_dir, checksum)
+            .context("while validating verity image")?;
+        Ok(())
+    }
+}
+
+impl File {
+    fn full_name(&self, base_dir: &Path) -> PathBuf {
+        let mut path = PathBuf::from(base_dir);
+        path.push(&self.name);
+        path
+    }
+
+    fn validate(&self, base_dir: &Path, _checksum: bool) -> anyhow::Result<()> {
+        let full_name = self.full_name(base_dir);
+        if !std::fs::exists(&full_name)? {
+            anyhow::bail!("Missing file {full_name}", full_name = full_name.display())
+        }
+        // FIXME: Add checksum validation as well
+        Ok(())
+    }
+}

--- a/crates/ota-update/src/image/mod.rs
+++ b/crates/ota-update/src/image/mod.rs
@@ -8,6 +8,9 @@ pub mod plan;
 pub mod runtime;
 pub mod slot;
 pub mod uki;
+pub mod version;
+
+pub use version::Version;
 
 #[cfg(test)]
 pub mod test;

--- a/crates/ota-update/src/image/mod.rs
+++ b/crates/ota-update/src/image/mod.rs
@@ -1,5 +1,13 @@
+pub mod cli;
+pub mod executor;
 pub mod group;
 pub mod lvm;
 pub mod manifest;
+pub mod pipeline;
+pub mod plan;
 pub mod runtime;
 pub mod slot;
+pub mod uki;
+
+#[cfg(test)]
+pub mod test;

--- a/crates/ota-update/src/image/mod.rs
+++ b/crates/ota-update/src/image/mod.rs
@@ -1,3 +1,5 @@
+pub mod group;
 pub mod lvm;
 pub mod manifest;
+pub mod runtime;
 pub mod slot;

--- a/crates/ota-update/src/image/mod.rs
+++ b/crates/ota-update/src/image/mod.rs
@@ -1,0 +1,3 @@
+pub mod lvm;
+pub mod manifest;
+pub mod slot;

--- a/crates/ota-update/src/image/pipeline.rs
+++ b/crates/ota-update/src/image/pipeline.rs
@@ -1,3 +1,5 @@
+use shell_escape::escape;
+use std::borrow::Cow;
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -68,24 +70,12 @@ impl Pipeline {
                 let mut s = cmd.program.clone();
                 for arg in &cmd.args {
                     s.push(' ');
-                    s.push_str(&shell_escape(arg));
+                    s.push_str(&escape(Cow::Borrowed(arg)));
                 }
                 s
             })
             .collect::<Vec<_>>()
             .join(" | ")
-    }
-}
-
-// Minimal, enough for MVP. Is not from user input, so relatively safe
-// FIXME: use some full featured escaper from crates.io
-fn shell_escape(s: &str) -> String {
-    if s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || "-_./=".contains(c))
-    {
-        s.to_string()
-    } else {
-        format!("'{}'", s.replace('\'', "'\"'\"'"))
     }
 }
 

--- a/crates/ota-update/src/image/pipeline.rs
+++ b/crates/ota-update/src/image/pipeline.rs
@@ -1,5 +1,4 @@
 use shell_escape::escape;
-use std::borrow::Cow;
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -70,7 +69,7 @@ impl Pipeline {
                 let mut s = cmd.program.clone();
                 for arg in &cmd.args {
                     s.push(' ');
-                    s.push_str(&escape(Cow::Borrowed(arg)));
+                    s.push_str(&escape(arg.into()));
                 }
                 s
             })

--- a/crates/ota-update/src/image/pipeline.rs
+++ b/crates/ota-update/src/image/pipeline.rs
@@ -13,6 +13,7 @@ pub struct Pipeline {
 }
 
 impl CommandSpec {
+    #[must_use]
     pub fn new<S: Into<String>>(program: S) -> Self {
         Self {
             program: program.into(),
@@ -20,16 +21,19 @@ impl CommandSpec {
         }
     }
 
+    #[must_use]
     pub fn arg_path<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.args.push(path.as_ref().to_string_lossy().into_owned());
         self
     }
 
+    #[must_use]
     pub fn arg<S: Into<String>>(mut self, arg: S) -> Self {
         self.args.push(arg.into());
         self
     }
 
+    #[must_use]
     pub fn args<I, S>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -40,28 +44,32 @@ impl CommandSpec {
     }
 }
 
-impl Into<Pipeline> for CommandSpec {
-    fn into(self) -> Pipeline {
-        Pipeline::new(self)
+impl From<CommandSpec> for Pipeline {
+    fn from(val: CommandSpec) -> Pipeline {
+        Pipeline::new(val)
     }
 }
 
 impl Pipeline {
+    #[must_use]
     pub fn new(first: CommandSpec) -> Self {
         Self {
             stages: vec![first],
         }
     }
 
+    #[must_use]
     pub fn pipe(mut self, next: CommandSpec) -> Self {
         self.stages.push(next);
         self
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.stages.is_empty()
     }
 
+    #[must_use]
     pub fn format_shell(&self) -> String {
         self.stages
             .iter()

--- a/crates/ota-update/src/image/pipeline.rs
+++ b/crates/ota-update/src/image/pipeline.rs
@@ -1,0 +1,97 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommandSpec {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pipeline {
+    pub stages: Vec<CommandSpec>,
+}
+
+impl CommandSpec {
+    pub fn new<S: Into<String>>(program: S) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg_path<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.args.push(path.as_ref().to_string_lossy().into_owned());
+        self
+    }
+
+    pub fn arg<S: Into<String>>(mut self, arg: S) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl Pipeline {
+    pub fn new(first: CommandSpec) -> Self {
+        Self {
+            stages: vec![first],
+        }
+    }
+
+    pub fn pipe(mut self, next: CommandSpec) -> Self {
+        self.stages.push(next);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stages.is_empty()
+    }
+
+    pub fn format_shell(&self) -> String {
+        self.stages
+            .iter()
+            .map(|cmd| {
+                let mut s = cmd.program.clone();
+                for arg in &cmd.args {
+                    s.push(' ');
+                    s.push_str(&shell_escape(arg));
+                }
+                s
+            })
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
+}
+
+// Minimal, enough for MVP. Is not from user input, so relatively safe
+// FIXME: use some full featured escaper from crates.io
+fn shell_escape(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || "-_./=".contains(c))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\"'\"'"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_shell_format() {
+        let p = Pipeline::new(CommandSpec::new("zstdcat").arg("root.zst"))
+            .pipe(CommandSpec::new("dd").arg("of=/dev/null"));
+
+        assert_eq!(p.format_shell(), "zstdcat root.zst | dd of=/dev/null");
+    }
+}

--- a/crates/ota-update/src/image/pipeline.rs
+++ b/crates/ota-update/src/image/pipeline.rs
@@ -39,6 +39,12 @@ impl CommandSpec {
     }
 }
 
+impl Into<Pipeline> for CommandSpec {
+    fn into(self) -> Pipeline {
+        Pipeline::new(self)
+    }
+}
+
 impl Pipeline {
     pub fn new(first: CommandSpec) -> Self {
         Self {

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -210,10 +210,10 @@ mod tests {
             "lvrename pool root_25.12.1_deadbeefdeadbeef root_empty_0",
             "lvrename pool verity_25.12.1_deadbeefdeadbeef verity_empty_0",
         ];
-        let version = Version::new("25.12.1", None);
+        let version = Version::new("25.12.1".into(), None);
         let plan = Plan::remove(&rt, &version).expect("remove failed");
         assert_eq!(plan.into_script(), expected);
-        let version = Version::new("25.12.1", Some("deadbeefdeadbeef"));
+        let version = Version::new("25.12.1".into(), Some("deadbeefdeadbeef".into()));
         let plan = Plan::remove(&rt, &version).expect("remove failed");
         assert_eq!(plan.into_script(), expected);
     }

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -124,8 +124,12 @@ impl Plan {
     }
 
     fn finalize_flush(volume: &Volume) -> Pipeline {
-        let dev = format!("/dev/mapper/{}-{}", volume.vg_name, volume.lv_name);
-        Pipeline::new(CommandSpec::new("blockdev").arg("--flushbufs").arg(dev))
+        let dev = volume.device_file();
+        Pipeline::new(
+            CommandSpec::new("blockdev")
+                .arg("--flushbufs")
+                .arg_path(dev.as_path()),
+        )
     }
 }
 

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -43,8 +43,8 @@ impl Plan {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("slot has no verity volume"))?;
 
-        steps.push(Self::install_volume(root.volume(), &m.store, source)?);
-        steps.push(Self::install_volume(verity.volume(), &m.verity, source)?);
+        steps.push(Self::install_volume(root.volume(), &m.store, source));
+        steps.push(Self::install_volume(verity.volume(), &m.verity, source));
         steps.push(Self::finalize_flush(root.volume()));
         steps.push(Self::finalize_flush(verity.volume()));
 
@@ -59,7 +59,7 @@ impl Plan {
         Ok(Plan { steps })
     }
 
-    fn install_volume(volume: &Volume, file: &File, source: &Path) -> anyhow::Result<Pipeline> {
+    fn install_volume(volume: &Volume, file: &File, source: &Path) -> Pipeline {
         let target = format!("/dev/mapper/{}-{}", volume.vg_name, volume.lv_name);
         let input = file.full_name(source);
 
@@ -80,7 +80,7 @@ impl Plan {
             )
         };
 
-        Ok(pipeline)
+        pipeline
     }
 
     fn install_uki(

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -4,8 +4,6 @@ use super::lvm::Volume;
 use super::manifest::{File, Manifest};
 use super::pipeline::{CommandSpec, Pipeline};
 use super::runtime::{Runtime, SlotSelection};
-use super::slot::{Kind, Slot};
-use super::uki::UkiEntry;
 use anyhow::bail;
 use std::path::Path;
 

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -1,0 +1,236 @@
+use super::group::SlotGroup;
+use super::lvm::Volume;
+use super::manifest::{File, Manifest};
+use super::pipeline::{CommandSpec, Pipeline};
+use super::runtime::{Runtime, SlotSelection};
+use super::slot::{Kind, Slot};
+use super::uki::UkiEntry;
+use anyhow::bail;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Plan {
+    pub steps: Vec<Pipeline>,
+}
+
+impl Plan {
+    pub fn install(rt: &Runtime, m: &Manifest, source: &Path) -> anyhow::Result<Self> {
+        let selection = rt.select_update_slot(m)?;
+
+        match selection {
+            SlotSelection::AlreadyInstalled => {
+                // nothing to do
+                Ok(Plan { steps: vec![] })
+            }
+
+            SlotSelection::Selected(slot) => Plan::install_into_slot(rt, m, &slot, source),
+        }
+    }
+
+    fn install_into_slot(
+        rt: &Runtime,
+        m: &Manifest,
+        slot: &SlotGroup,
+        source: &Path,
+    ) -> anyhow::Result<Self> {
+        let mut steps = Vec::new();
+
+        let root = slot
+            .root
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("slot has no root volume"))?;
+        let verity = slot
+            .verity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("slot has no verity volume"))?;
+
+        steps.push(Self::install_volume(root, &m.store, source)?);
+        steps.push(Self::install_volume(verity, &m.verity, source)?);
+        steps.push(Self::finalize_flush(root));
+        steps.push(Self::finalize_flush(verity));
+
+        // FIXME: rewrite!
+        let newname = Slot {
+            kind: Kind::Root,
+            version: Some(m.version.clone()),
+            hash: Some(m.hash_fragment().to_string()),
+        };
+        steps.push(Self::finalize_lvrename(root, &newname.to_string()));
+
+        // FIXME: rewrite!
+        let newname = Slot {
+            kind: Kind::Verity,
+            version: Some(m.version.clone()),
+            hash: Some(m.hash_fragment().to_string()),
+        };
+        steps.push(Self::finalize_lvrename(verity, &newname.to_string()));
+        steps.push(Self::install_uki(slot, &m.kernel, &rt.boot, source)?);
+
+        Ok(Plan { steps })
+    }
+
+    fn install_volume(volume: &Volume, file: &File, source: &Path) -> anyhow::Result<Pipeline> {
+        let target = format!("/dev/mapper/{}-{}", volume.vg_name, volume.lv_name);
+        let input = file.full_name(source);
+
+        let pipeline = if file.is_compressed() {
+            Pipeline::new(CommandSpec::new("zstdcat").arg_path(input)).pipe(
+                CommandSpec::new("dd")
+                    .arg(format!("of={target}"))
+                    .arg("bs=4M")
+                    .arg("status=progress"),
+            )
+        } else {
+            Pipeline::new(
+                CommandSpec::new("dd")
+                    .arg(format!("if={input}", input = input.to_string_lossy()))
+                    .arg(format!("of={target}"))
+                    .arg("bs=4M")
+                    .arg("status=progress"),
+            )
+        };
+
+        Ok(pipeline)
+    }
+
+    fn install_uki(
+        slot: &SlotGroup,
+        file: &File,
+        boot: &str,
+        source: &Path,
+    ) -> anyhow::Result<Pipeline> {
+        let uki_name = slot
+            .uki
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("cannot determine UKI name for slot"))?;
+
+        Ok(Pipeline::new(
+            CommandSpec::new("install")
+                .arg("-m")
+                .arg("0644")
+                .arg_path(file.full_name(source))
+                .arg(format!("{boot}/EFI/Linux/{uki_name}")),
+        ))
+    }
+
+    fn finalize_lvrename(volume: &Volume, final_name: &str) -> Pipeline {
+        Pipeline::new(
+            CommandSpec::new("lvrename")
+                .arg(&volume.vg_name)
+                .arg(&volume.lv_name)
+                .arg(final_name),
+        )
+    }
+
+    fn finalize_flush(volume: &Volume) -> Pipeline {
+        let dev = format!("/dev/mapper/{}-{}", volume.vg_name, volume.lv_name);
+        Pipeline::new(CommandSpec::new("blockdev").arg("--flushbufs").arg(dev))
+    }
+}
+
+impl Plan {
+    pub fn remove(rt: &Runtime, version: &str, hash: Option<&str>) -> anyhow::Result<Self> {
+        let slot = rt.find_slot(version, hash)?;
+
+        if slot.is_active(&rt.kernel) {
+            bail!("cannot remove active slot");
+        }
+
+        let mut steps = Vec::new();
+
+        // Remove UKI if present
+        if let Some(uki) = &slot.uki {
+            steps.push(Self::remove_uki(rt, uki));
+        }
+
+        // Full slot: rename to empty
+        let empty_id = match &slot.hash {
+            Some(h) if !rt.has_empty_with_hash(h) => h.clone(),
+            _ => rt.allocate_empty_identifier()?,
+        };
+
+        steps.extend(Self::rename_slot_to_empty(&slot, &empty_id));
+
+        Ok(Plan { steps })
+    }
+
+    fn remove_uki(rt: &Runtime, uki: &UkiEntry) -> Pipeline {
+        Pipeline::new(
+            CommandSpec::new("rm")
+                .arg("-f")
+                .arg_path(uki.full_name(&rt.boot)),
+        )
+    }
+
+    fn rename_slot_to_empty(slot: &SlotGroup, empty_id: &str) -> Vec<Pipeline> {
+        let mut steps = Vec::new();
+
+        if let Some(root) = &slot.root {
+            steps.push(Pipeline::new(
+                CommandSpec::new("lvrename")
+                    .arg(&root.vg_name)
+                    .arg(&root.lv_name)
+                    .arg(format!("root_empty_{empty_id}")),
+            ));
+        }
+
+        if let Some(verity) = &slot.verity {
+            steps.push(Pipeline::new(
+                CommandSpec::new("lvrename")
+                    .arg(&verity.vg_name)
+                    .arg(&verity.lv_name)
+                    .arg(format!("verity_empty_{empty_id}")),
+            ));
+        }
+
+        steps
+    }
+}
+
+#[cfg(test)]
+impl Plan {
+    fn into_script(self) -> Vec<String> {
+        self.steps
+            .into_iter()
+            .map(|step| step.format_shell())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::test::*;
+
+    #[test]
+    fn install() {
+        let rt = make_test_runtime();
+        let m = make_test_manifest();
+        let expected = &[
+            "zstdcat /sysupdate/ghaf_root_25.12.1_44cc41b403a2d323.raw.zst | dd of=/dev/mapper/pool-root_empty bs=4M status=progress",
+            "zstdcat /sysupdate/ghaf_verity_25.12.1_44cc41b403a2d323.raw.zst | dd of=/dev/mapper/pool-verity_empty bs=4M status=progress",
+            "blockdev --flushbufs /dev/mapper/pool-root_empty",
+            "blockdev --flushbufs /dev/mapper/pool-verity_empty",
+            "lvrename pool root_empty root_25.12.1_44cc41b403a2d323",
+            "lvrename pool verity_empty verity_25.12.1_44cc41b403a2d323",
+            "install -m 0644 /sysupdate/ghaf_kernel_25.12.1_44cc41b403a2d323.efi /boot/EFI/Linux/ghaf-25.12.1-44cc41b403a2d323.efi",
+        ];
+
+        let plan = Plan::install(&rt, &m, &Path::new("/sysupdate")).expect("install failed");
+        assert_eq!(plan.into_script(), expected)
+    }
+
+    #[test]
+    fn remove() {
+        let rt = make_test_runtime_installed();
+        let expected = &[
+            // FIXME: UKI removal?
+            "lvrename pool root_25.12.1_deadbeefdeadbeef root_empty_0",
+            "lvrename pool verity_25.12.1_deadbeefdeadbeef verity_empty_0",
+        ];
+        let plan = Plan::remove(&rt, "25.12.1", None).expect("remove failed");
+        assert_eq!(plan.into_script(), expected);
+        let plan = Plan::remove(&rt, "25.12.1", Some("deadbeefdeadbeef")).expect("remove failed");
+        assert_eq!(plan.into_script(), expected);
+    }
+}

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -240,4 +240,17 @@ mod tests {
         let plan = Plan::remove(&rt, &version).expect("remove failed");
         assert_eq!(plan.into_script(), expected);
     }
+
+    #[test]
+    fn remove_legacy() {
+        let rt = make_test_runtime_installed();
+        let expected = &[
+            "bootctl unlink nixos-generation-1.conf",
+            "lvrename pool root_0 root_empty_0",
+            "lvrename pool verity_0 verity_empty_0",
+        ];
+        let version = Version::new("0".into(), None);
+        let plan = Plan::remove(&rt, &version).expect("remove failed");
+        assert_eq!(plan.into_script(), expected);
+    }
 }

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -147,7 +147,14 @@ impl Plan {
 
         // Remove UKI if present
         if let Some(boot) = &slot.boot {
-            steps.push(boot.clone().to_remove()); // FIXME: clone
+            steps.push(boot.to_remove());
+        }
+
+        // Remove legacy boot entries, if any
+        if slot.is_legacy() {
+            for boot in rt.boot_entries.iter().filter(|boot| boot.is_legacy()) {
+                steps.push(boot.to_remove())
+            }
         }
 
         steps.extend(Self::rename_slot_to_empty(&slot, &empty_id));
@@ -198,7 +205,7 @@ mod tests {
     use crate::image::test::*;
 
     #[test]
-    fn install() {
+    fn install_from_legacy() {
         let rt = make_test_runtime();
         let m = make_test_manifest();
         let expected = &[
@@ -222,7 +229,7 @@ mod tests {
     fn remove() {
         let rt = make_test_runtime_installed();
         let expected = &[
-            // FIXME: UKI removal?
+            "bootctl unlink ghaf-25.12.1-deadbeefdeadbeef.efi",
             "lvrename pool root_25.12.1_deadbeefdeadbeef root_empty_0",
             "lvrename pool verity_25.12.1_deadbeefdeadbeef verity_empty_0",
         ];

--- a/crates/ota-update/src/image/plan.rs
+++ b/crates/ota-update/src/image/plan.rs
@@ -60,7 +60,7 @@ impl Plan {
     }
 
     fn install_volume(volume: &Volume, file: &File, source: &Path) -> Pipeline {
-        let target = format!("/dev/mapper/{}-{}", volume.vg_name, volume.lv_name);
+        let target = volume.device_file_string();
         let input = file.full_name(source);
 
         let pipeline = if file.is_compressed() {

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -43,7 +43,7 @@ impl Runtime {
         let volumes = parse_lvs_output(lvs);
         let (slots, volumes) = Slot::from_volumes(volumes);
         let boot_entries = BootEntry::from_bootctl(bootctl);
-        let (managed, unmanaged) = boot_entries.into_iter().partition(|x| x.is_managed());
+        let (managed, unmanaged) = boot_entries.into_iter().partition(BootEntry::is_managed);
         let slots = SlotGroup::group_volumes(slots, managed)?;
         Ok(Self {
             slots,
@@ -194,11 +194,11 @@ impl Runtime {
             if let Some(version) = group.version() {
                 out.push_str(&format!("  version: {}", version.revision));
                 if let Some(hash) = &version.hash {
-                    out.push_str(&format!(" (hash={})", hash));
+                    out.push_str(&format!(" (hash={hash})"));
                 }
                 out.push('\n');
             } else if let Some(id) = group.empty_id() {
-                out.push_str(&format!("  id: {}\n", id));
+                out.push_str(&format!("  id: {id}\n"));
             } else {
                 out.push_str("  id: <none>\n");
             }
@@ -236,7 +236,7 @@ impl Runtime {
             // UKI
             match &group.boot {
                 Some(boot) => {
-                    out.push_str(&format!("  boot: {}\n", boot));
+                    out.push_str(&format!("  boot: {boot}\n"));
                 }
                 None => out.push_str("  boot: <none>\n"),
             }

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -1,6 +1,6 @@
 use super::Version;
 use super::group::SlotGroup;
-use super::lvm::{Volume, parse_lvs_output};
+use super::lvm::Volume;
 use super::manifest::Manifest;
 use super::slot::{Slot, SlotClass};
 use super::uki::{BootEntry, BootEntryKind, UkiEntry};
@@ -39,8 +39,7 @@ impl SlotSelection {
 }
 
 impl Runtime {
-    pub fn new(lvs: &str, cmdline: &str, bootctl: Vec<BootctlItem>) -> Result<Self> {
-        let volumes = parse_lvs_output(lvs);
+    pub fn new(volumes: Vec<Volume>, cmdline: &str, bootctl: Vec<BootctlItem>) -> Result<Self> {
         let (slots, volumes) = Slot::from_volumes(volumes);
         let boot_entries = BootEntry::from_bootctl(bootctl);
         let (managed, unmanaged) = boot_entries.into_iter().partition(BootEntry::is_managed);
@@ -352,7 +351,7 @@ impl Default for Runtime {
 mod tests {
     use super::*;
 
-    use crate::image::test::{groups, manifest, volume};
+    use crate::image::test::{groups, manifest};
 
     // complete root + verity slot
     #[test]
@@ -415,7 +414,7 @@ mod tests {
     #[test]
     fn non_slot_volumes_are_ignored() {
         let rt = Runtime {
-            volumes: vec![volume("swap"), volume("home")],
+            volumes: vec![Volume::new("swap"), Volume::new("home")],
             slots: groups(&vec!["root_1.0.0_aaaaaaaaaaaaaaaa"]),
             ..Runtime::default()
         };

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -1,12 +1,11 @@
 use super::Version;
 use super::group::SlotGroup;
 use super::lvm::{Volume, parse_lvs_output};
-use super::manifest::{File, Manifest};
-use super::slot::{Kind, Slot, SlotClass};
+use super::manifest::Manifest;
+use super::slot::{Slot, SlotClass};
 use super::uki::{BootEntry, UkiEntry};
 use crate::bootctl::BootctlItem;
 use anyhow::{Result, anyhow, bail};
-use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
 pub struct Runtime {

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -1,3 +1,4 @@
+use super::Version;
 use super::group::{SlotGroup, group_volumes};
 use super::lvm::{Volume, parse_lvs_output};
 use super::manifest::{File, Manifest};
@@ -171,6 +172,15 @@ impl KernelParams {
 
     pub fn verity_hash_fragment(&self) -> Option<&str> {
         self.store_hash.as_deref().map(|h| &h[..16])
+    }
+
+    pub fn to_version(&self) -> Option<Version> {
+        self.revision.as_deref().map(|r| {
+            Version::new(
+                r.to_string(),
+                self.verity_hash_fragment().map(|h| h.to_string()),
+            )
+        })
     }
 }
 

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -179,7 +179,7 @@ impl Runtime {
 
     /// Human-readable runtime introspection.
     /// Intended for debugging, dry-run output and diagnostics.
-    pub fn inspect(&self) -> anyhow::Result<String> {
+    pub fn inspect(&self) -> String {
         let mut out = String::new();
 
         let groups = self.slot_groups();
@@ -257,7 +257,7 @@ impl Runtime {
             }
         }
 
-        Ok(out)
+        out
     }
 }
 

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -37,16 +37,16 @@ impl SlotSelection {
 }
 
 impl Runtime {
-    pub fn new(lvs: &str, cmdline: &str, bootctl: &Vec<BootctlItem>) -> Self {
+    pub fn new(lvs: &str, cmdline: &str, bootctl: &Vec<BootctlItem>) -> Result<Self> {
         let volumes = parse_lvs_output(lvs);
         let (slots, volumes) = Slot::from_volumes(volumes);
-        Self {
+        Ok(Self {
             slots,
             volumes,
             kernel: KernelParams::from_cmdline(cmdline),
             ukis: UkiEntry::from_bootctl(bootctl),
             boot: "/boot".into(), // FIXME: detect /boot if possible
-        }
+        })
     }
 
     pub fn slots_by_class<'a>(

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -288,7 +288,8 @@ fn format_size(size: Option<u64>) -> String {
 }
 
 /// The name of the kernel commandline argument
-const CMDLINE_ARG_NAME: &str = "storehash";
+// FIXME: make both names configurable at compile time
+const CMDLINE_ARG_NAME: &str = "ghaf.storehash";
 const GHAF_REVISION_NAME: &str = "ghaf.revision";
 
 impl KernelParams {

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -28,19 +28,25 @@ pub struct KernelParams {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum SlotSelection {
     AlreadyInstalled,
     Selected(SlotGroup),
 }
 
 impl SlotSelection {
+    #[must_use]
     pub fn is_none(&self) -> bool {
         matches!(&self, Self::AlreadyInstalled)
     }
 }
 
 impl Runtime {
-    pub fn new(volumes: Vec<Volume>, cmdline: &str, bootctl: Vec<BootctlItem>) -> Result<Self> {
+    pub(crate) fn new(
+        volumes: Vec<Volume>,
+        cmdline: &str,
+        bootctl: Vec<BootctlItem>,
+    ) -> Result<Self> {
         let (slots, volumes) = Slot::from_volumes(volumes);
         let boot_entries = BootEntry::from_bootctl(bootctl);
         let (managed, unmanaged) = boot_entries.into_iter().partition(BootEntry::is_managed);
@@ -64,11 +70,12 @@ impl Runtime {
             .filter(move |g| g.classify(&self.kernel) == class)
     }
 
+    #[must_use]
     pub fn slot_groups(&self) -> &Vec<SlotGroup> {
         &self.slots
     }
 
-    pub fn select_update_slot(&self, manifest: &Manifest) -> Result<SlotSelection> {
+    pub(crate) fn select_update_slot(&self, manifest: &Manifest) -> Result<SlotSelection> {
         let slots = self.slot_groups();
         let target = manifest.to_version();
 
@@ -82,9 +89,8 @@ impl Runtime {
 
         // 2. Find first suitable empty slot
         let slot = slots
-            .into_iter()
-            .filter(|slot| slot.is_empty() && !slot.is_active(&self.kernel) && slot.is_complete())
-            .next()
+            .iter()
+            .find(|slot| slot.is_empty() && !slot.is_active(&self.kernel) && slot.is_complete())
             .context("no empty slot available for update")?;
 
         // 3. Attach UKI metadata for the plan
@@ -96,7 +102,7 @@ impl Runtime {
         Ok(SlotSelection::Selected(slot))
     }
 
-    pub fn find_slot_group<'a>(&'a self, version: &Version) -> Result<&'a SlotGroup> {
+    pub(crate) fn find_slot_group<'a>(&'a self, version: &Version) -> Result<&'a SlotGroup> {
         let groups = self.slot_groups();
 
         // 1. exact match
@@ -126,7 +132,7 @@ impl Runtime {
         bail!("slot not found: version={version}");
     }
 
-    pub fn active_slot(&self) -> Result<&SlotGroup> {
+    pub(crate) fn active_slot(&self) -> Result<&SlotGroup> {
         let mut active = self
             .slot_groups()
             .iter()
@@ -135,16 +141,13 @@ impl Runtime {
         let first = active.next().context("no active slot detected")?;
 
         if let Some(second) = active.next() {
-            bail!(
-                "multiple active slots detected: {:?} and {:?}",
-                first,
-                second
-            );
+            bail!("multiple active slots detected: {first:?} and {second:?}",);
         }
 
         Ok(first)
     }
 
+    #[must_use]
     pub fn has_empty_with_hash(&self, hash: &str) -> bool {
         self.slot_groups()
             .iter()
@@ -152,7 +155,7 @@ impl Runtime {
     }
 
     // NOTE: This algoritm intentionally avoid HashMap/HashSet, because we have only 2-3 slots
-    pub fn allocate_empty_identifier(&self) -> Result<String> {
+    pub(crate) fn allocate_empty_identifier(&self) -> Result<String> {
         let groups = self.slot_groups();
         let used: Vec<&str> = groups.iter().filter_map(|s| s.empty_id()).collect();
 
@@ -168,6 +171,7 @@ impl Runtime {
 
     /// Human-readable runtime introspection.
     /// Intended for debugging, dry-run output and diagnostics.
+    #[must_use]
     pub fn inspect(&self) -> String {
         let mut out = String::new();
 
@@ -272,12 +276,14 @@ impl Runtime {
     }
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn format_size(size: Option<u64>) -> String {
+    const G: u64 = 1024 * 1024 * 1024;
+
     let Some(bytes) = size else {
         return String::new();
     };
 
-    const G: u64 = 1024 * 1024 * 1024;
     format!(" ({:.1}G)", bytes as f64 / G as f64)
 }
 
@@ -308,16 +314,18 @@ impl KernelParams {
         })
     }
 
+    #[must_use]
     pub fn verity_hash_fragment(&self) -> Option<&str> {
-        // SAFETY: We ensure that hash always equal 64 characters
+        // SAFETY: We ensure that hash always equal 64 characters in constructor above
         self.store_hash.as_deref().map(|h| &h[..16])
     }
 
+    #[must_use]
     pub fn to_version(&self) -> Option<Version> {
         self.revision.as_deref().map(|r| {
             Version::new(
                 r.to_string(),
-                self.verity_hash_fragment().map(|h| h.to_string()),
+                self.verity_hash_fragment().map(ToString::to_string),
             )
         })
     }

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -1,0 +1,330 @@
+use super::group::{SlotGroup, group_volumes};
+use super::lvm::{Volume, parse_lvs_output};
+use super::manifest::{File, Manifest};
+use super::slot::{Kind, Slot, SlotClass};
+use anyhow::{Result, anyhow};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Runtime {
+    pub volumes: Vec<Volume>,
+    pub kernel: KernelParams,
+}
+
+/// Well-known params from kernel /proc/cmdline
+#[derive(Debug, Clone)]
+pub struct KernelParams {
+    pub store_hash: Option<String>,
+    pub revision: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum SlotSelection {
+    AlreadyInstalled,
+    Selected(SlotGroup),
+}
+
+impl SlotSelection {
+    pub fn is_none(&self) -> bool {
+        matches!(&self, Self::AlreadyInstalled)
+    }
+}
+
+impl Runtime {
+    fn new(lvs: &str, cmdline: &str) -> Self {
+        Self {
+            volumes: parse_lvs_output(lvs),
+            kernel: KernelParams::from_cmdline(cmdline),
+        }
+    }
+
+    pub fn slots_by_class<'a>(
+        &'a self,
+        groups: &'a [SlotGroup],
+        class: SlotClass,
+    ) -> impl Iterator<Item = &'a SlotGroup> {
+        groups
+            .iter()
+            .filter(move |g| g.classify(&self.kernel) == class)
+    }
+
+    pub fn slot_groups(&self) -> Result<Vec<SlotGroup>> {
+        group_volumes(&self.volumes)
+    }
+
+    pub fn select_update_slot(&self, manifest: &Manifest) -> Result<SlotSelection> {
+        let slots = self.slot_groups()?;
+        let target_hash = manifest.hash_fragment();
+
+        // 1. Check if target already installed
+        if slots.iter().any(|slot| {
+            slot.version.as_deref() == Some(&manifest.version)
+                && slot.hash.as_deref() == Some(target_hash)
+                && slot.is_complete()
+        }) {
+            return Ok(SlotSelection::AlreadyInstalled);
+        }
+
+        println!("slots = {:?}", slots);
+        // 2. Find empty, non-active slots
+        let mut empty_slots = slots
+            .into_iter()
+            .filter(|slot| !slot.is_active(&self.kernel))
+            .filter(|slot| slot.is_complete())
+            .filter(|slot| slot.is_empty());
+
+        // 3. Select one
+        if let Some(slot) = empty_slots.next() {
+            Ok(SlotSelection::Selected(slot))
+        } else {
+            Err(anyhow!("no empty slot available for update"))
+        }
+    }
+}
+
+/// The name of the kernel commandline argument
+const CMDLINE_ARG_NAME: &str = "storehash";
+const GHAF_REVISION_NAME: &str = "ghaf.revision";
+
+impl KernelParams {
+    /// Parse the storehash from a provided kernel commandline
+    fn from_cmdline(cmdline: &str) -> Self {
+        let storehash_arg = cmdline
+            .split_whitespace()
+            .find(|&s| s.contains(&format!("{CMDLINE_ARG_NAME}=")));
+        let revision_arg = cmdline
+            .split_whitespace()
+            .find(|&s| s.contains(&format!("{GHAF_REVISION_NAME}=")));
+        let revision = revision_arg.and_then(|r| r.split("=").last());
+        let store_hash = storehash_arg.and_then(|h| h.split("=").last());
+        Self {
+            store_hash: store_hash.map(ToOwned::to_owned),
+            revision: revision.map(ToOwned::to_owned),
+        }
+    }
+
+    pub fn verity_hash_fragment(&self) -> Option<&str> {
+        self.store_hash.as_deref().map(|h| &h[..16])
+    }
+}
+
+#[cfg(test)]
+impl Default for KernelParams {
+    fn default() -> Self {
+        Self {
+            revision: None,
+            store_hash: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vol(name: &str) -> Volume {
+        Volume {
+            lv_name: name.to_string(),
+            vg_name: "vg".into(),
+            lv_attr: None,
+            lv_size_bytes: None,
+        }
+    }
+
+    // complete root + verity slot
+    #[test]
+    fn groups_root_and_verity_into_single_slot() {
+        let rt = Runtime {
+            volumes: vec![
+                vol("root_1.2.3_deadbeefdeadbeef"),
+                vol("verity_1.2.3_deadbeefdeadbeef"),
+            ],
+            kernel: KernelParams::default(),
+        };
+
+        let groups = rt.slot_groups().expect("group");
+        assert_eq!(groups.len(), 1);
+
+        let g = &groups[0];
+        assert_eq!(g.version.as_deref(), Some("1.2.3"));
+        assert_eq!(g.hash.as_deref(), Some("deadbeefdeadbeef"));
+        assert!(g.root.is_some());
+        assert!(g.verity.is_some());
+    }
+
+    // empty slot (version = empty)
+    #[test]
+    fn empty_slot_is_grouped() {
+        let rt = Runtime {
+            volumes: vec![vol("root_empty_01"), vol("verity_empty_01")],
+            kernel: KernelParams::default(),
+        };
+
+        let groups = rt.slot_groups().expect("group");
+        assert_eq!(groups.len(), 1);
+
+        let g = &groups[0];
+        assert_eq!(g.version, None);
+        assert_eq!(g.hash.as_deref(), Some("01"));
+    }
+
+    // broken slot (only root)
+    #[test]
+    fn broken_slot_with_only_root_is_preserved() {
+        let rt = Runtime {
+            volumes: vec![vol("root_2.0.0_abcdabcdabcdabcd")],
+            kernel: KernelParams::default(),
+        };
+
+        let groups = rt.slot_groups().expect("group");
+        assert_eq!(groups.len(), 1);
+
+        let g = &groups[0];
+        assert!(g.root.is_some());
+        assert!(g.verity.is_none());
+    }
+
+    #[test]
+    fn non_slot_volumes_are_ignored() {
+        let rt = Runtime {
+            volumes: vec![vol("swap"), vol("home"), vol("root_1.0.0_aaaaaaaaaaaaaaaa")],
+            kernel: KernelParams::default(),
+        };
+
+        let groups = rt.slot_groups().expect("group");
+        assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn multiple_slots_are_grouped_separately() {
+        let rt = Runtime {
+            volumes: vec![
+                vol("root_1.0.0_aaaaaaaaaaaaaaaa"),
+                vol("verity_1.0.0_aaaaaaaaaaaaaaaa"),
+                vol("root_2.0.0_bbbbbbbbbbbbbbbb"),
+                vol("verity_2.0.0_bbbbbbbbbbbbbbbb"),
+            ],
+            kernel: KernelParams::default(),
+        };
+
+        let mut groups = rt.slot_groups().expect("group");
+        groups.sort_by(|a, b| a.version.cmp(&b.version));
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].version.as_deref(), Some("1.0.0"));
+        assert_eq!(groups[1].version.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn legacy_slot_is_grouped_correctly() {
+        let rt = Runtime {
+            volumes: vec![vol("root_0_deadbeefdeadbeef")],
+            kernel: KernelParams::default(),
+        };
+
+        let groups = rt.slot_groups().expect("group");
+        assert_eq!(groups.len(), 1);
+
+        let g = &groups[0];
+        assert_eq!(g.version.as_deref(), Some("0"));
+    }
+
+    fn manifest(version: &str, hash: &str) -> Manifest {
+        Manifest {
+            meta: Default::default(),
+            version: version.into(),
+            verity_root_hash: hash.into(),
+            kernel: File {
+                name: "k".into(),
+                sha256sum: "x".into(),
+            },
+            store: File {
+                name: "s".into(),
+                sha256sum: "x".into(),
+            },
+            verity: File {
+                name: "v".into(),
+                sha256sum: "x".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn select_slot_noop_if_version_already_installed() {
+        let rt = Runtime {
+            volumes: vec![
+                vol("root_1.2.3_deadbeefdeadbeef"),
+                vol("verity_1.2.3_deadbeefdeadbeef"),
+            ],
+            kernel: KernelParams {
+                revision: Some("1.2.3".into()),
+                store_hash: Some("deadbeefdeadbeef".into()),
+            },
+        };
+
+        let m = manifest("1.2.3", "deadbeefdeadbeef");
+
+        let res = rt.select_update_slot(&m).unwrap();
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn select_empty_slot_pair() {
+        let rt = Runtime {
+            volumes: vec![
+                vol("root_1.0.0_aaaaaaaaaaaaaaaa"),
+                vol("verity_1.0.0_aaaaaaaaaaaaaaaa"),
+                vol("root_empty_01"),
+                vol("verity_empty_01"),
+            ],
+            kernel: KernelParams {
+                revision: Some("1.0.0".into()),
+                store_hash: Some("aaaaaaaaaaaaaaaa".into()),
+            },
+        };
+
+        let m = manifest("2.0.0", "bbbbbbbbbbbbbbbb");
+
+        let SlotSelection::Selected(slot) = rt.select_update_slot(&m).expect("slot expected")
+        else {
+            panic!("Expect Selected()")
+        };
+        assert!(slot.is_empty());
+    }
+
+    #[test]
+    fn incomplete_empty_slot_is_not_selected() {
+        let rt = Runtime {
+            volumes: vec![vol("root_empty_01")],
+            kernel: KernelParams::default(),
+        };
+
+        let m = manifest("1.0.0", "aaaaaaaaaaaaaaaa");
+
+        let err = rt.select_update_slot(&m).unwrap_err();
+        assert!(err.to_string().contains("no empty slot"));
+    }
+
+    // Few empty slots, choose any free of them
+    // NOTE: We don't check determinism, only fact of successful choice
+    #[test]
+    fn one_of_multiple_empty_slots_is_selected() {
+        let rt = Runtime {
+            volumes: vec![
+                vol("root_empty_01"),
+                vol("verity_empty_01"),
+                vol("root_empty_02"),
+                vol("verity_empty_02"),
+            ],
+            kernel: KernelParams::default(),
+        };
+
+        let m = manifest("1.0.0", "aaaaaaaaaaaaaaaa");
+
+        let SlotSelection::Selected(slot) = rt.select_update_slot(&m).expect("slot expected")
+        else {
+            panic!("Selected() expected")
+        };
+        assert!(slot.is_empty());
+    }
+}

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -5,7 +5,7 @@ use super::manifest::Manifest;
 use super::slot::{Slot, SlotClass};
 use super::uki::{BootEntry, BootEntryKind, UkiEntry};
 use crate::bootctl::BootctlItem;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow, bail, ensure};
 use std::fmt::Write;
 
 #[derive(Debug)]
@@ -23,7 +23,7 @@ pub struct Runtime {
 /// Well-known params from kernel /proc/cmdline
 #[derive(Debug, Clone)]
 pub struct KernelParams {
-    pub store_hash: Option<String>,
+    store_hash: Option<String>,
     pub revision: Option<String>,
 }
 
@@ -48,7 +48,7 @@ impl Runtime {
         Ok(Self {
             slots,
             volumes,
-            kernel: KernelParams::from_cmdline(cmdline),
+            kernel: KernelParams::from_cmdline(cmdline)?,
             boot_entries: unmanaged,
             boot: "/boot".into(), // FIXME: detect /boot if possible
         })
@@ -297,14 +297,22 @@ impl KernelParams {
     }
 
     /// Parse the storehash from a provided kernel commandline
-    fn from_cmdline(cmdline: &str) -> Self {
-        Self {
-            store_hash: Self::find_arg(cmdline, CMDLINE_ARG_NAME).map(ToOwned::to_owned),
+    fn from_cmdline(cmdline: &str) -> Result<Self> {
+        let store_hash = Self::find_arg(cmdline, CMDLINE_ARG_NAME).map(ToOwned::to_owned);
+        ensure!(
+            store_hash
+                .as_ref()
+                .is_none_or(|hash| hash.chars().all(|c| c.is_ascii_hexdigit()) && hash.len() == 64),
+            "Invalid verity hash"
+        );
+        Ok(Self {
+            store_hash,
             revision: Self::find_arg(cmdline, GHAF_REVISION_NAME).map(ToOwned::to_owned),
-        }
+        })
     }
 
     pub fn verity_hash_fragment(&self) -> Option<&str> {
+        // SAFETY: We ensure that hash always equal 64 characters
         self.store_hash.as_deref().map(|h| &h[..16])
     }
 
@@ -573,5 +581,28 @@ mod tests {
 
         assert!(active.is_legacy());
         assert!(active.is_active(&rt.kernel));
+    }
+
+    // Following two test copied from ghaf-store-veritysetup-generator.
+    // If you change them here, update them there as well.
+    #[test]
+    fn invalid_verity_hash_chars() {
+        let expected_storehash = "invalid2dbec8355df07f3670177b0cb147683a355c07da6a2fb85313cc02254";
+        let expected_revision = "25.12.2";
+        let cmdline = format!(
+            "{CMDLINE_ARG_NAME}={expected_storehash} {GHAF_REVISION_NAME}={expected_revision}"
+        );
+        assert!(KernelParams::from_cmdline(&cmdline).is_err())
+    }
+
+    #[test]
+    // Most important test, cutting 16 chars of too short hash could panic
+    fn invalid_verity_hash_too_short() {
+        let expected_storehash = "94821122db";
+        let expected_revision = "25.12.2";
+        let cmdline = format!(
+            "{CMDLINE_ARG_NAME}={expected_storehash} {GHAF_REVISION_NAME}={expected_revision}"
+        );
+        assert!(KernelParams::from_cmdline(&cmdline).is_err())
     }
 }

--- a/crates/ota-update/src/image/runtime.rs
+++ b/crates/ota-update/src/image/runtime.rs
@@ -89,10 +89,13 @@ impl Runtime {
 
         // 3. Attach UKI metadata for the plan
         let slot = SlotGroup {
-            uki: Some(UkiEntry {
-                version: target,
-                boot_counter: None,
-            }),
+            boot: Some(
+                (UkiEntry {
+                    version: target,
+                    boot_counter: None,
+                })
+                .into(),
+            ),
             ..slot
         };
 
@@ -234,11 +237,11 @@ impl Runtime {
             }
 
             // UKI
-            match &group.uki {
-                Some(uki) => {
-                    out.push_str(&format!("  uki: {}\n", uki.full_name(&self.boot).display()));
+            match &group.boot {
+                Some(boot) => {
+                    out.push_str(&format!("  boot: {}\n", boot));
                 }
-                None => out.push_str("  uki: <none>\n"),
+                None => out.push_str("  boot: <none>\n"),
             }
 
             out.push('\n');

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -1,7 +1,7 @@
 use super::Version;
 use super::lvm::Volume;
 use super::pipeline::{CommandSpec, Pipeline};
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Context, Result, ensure};
 use std::fmt;
 use strum::EnumString;
 
@@ -51,8 +51,8 @@ impl Slot {
         // split from the right: [name]_[version]_[hash?]
         let mut parts = value.rsplitn(3, '_');
 
-        let last = parts.next().ok_or_else(|| anyhow!("empty input"))?;
-        let middle = parts.next().ok_or_else(|| anyhow!("missing version"))?;
+        let last = parts.next().context("empty input")?;
+        let middle = parts.next().context("missing version")?;
         let first = parts.next();
 
         let (name, version_raw, hash_or_id) =
@@ -224,15 +224,7 @@ impl Slot {
     /// Slot kind (root / verity) is intentionally ignored.
     #[must_use]
     pub fn matches(&self, other: &Slot) -> bool {
-        match (&self.status, &other.status) {
-            (Status::Used(a), Status::Used(b)) => a == b,
-
-            (Status::Empty(EmptyId::Known(a)), Status::Empty(EmptyId::Known(b))) => a == b,
-
-            (Status::Empty(EmptyId::Legacy), Status::Empty(EmptyId::Legacy)) => true,
-
-            _ => false,
-        }
+        self.status == other.status
     }
 }
 

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -125,11 +125,11 @@ impl fmt::Display for Slot {
             Status::Used(version) => {
                 write!(f, "{}_{}", self.kind, version.revision)?;
                 if let Some(hash) = &version.hash {
-                    write!(f, "_{}", hash)?;
+                    write!(f, "_{hash}")?;
                 }
             }
             Status::Empty(EmptyId::Known(id)) => {
-                write!(f, "{}_empty_{}", self.kind, id)?;
+                write!(f, "{}_empty_{id}", self.kind)?;
             }
             Status::Empty(EmptyId::Legacy) => {
                 write!(f, "{}_empty", self.kind)?;
@@ -204,13 +204,13 @@ impl Slot {
     #[must_use]
     pub fn version(&self) -> Option<&Version> {
         match &self.status {
-            Status::Used(version) => Some(&version),
+            Status::Used(version) => Some(version),
             _ => None,
         }
     }
 
     #[must_use]
-    pub fn into_version(self, version: Version) -> Result<Self> {
+    pub(crate) fn into_version(self, version: Version) -> Result<Self> {
         ensure!(!self.is_used(), "Can't assign version to already used slot");
         Ok(Self {
             status: Status::Used(version),

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -68,7 +68,7 @@ impl Slot {
         } else {
             Status::Used(Version::new(
                 version_raw.to_string(),
-                hash_or_id.map(|x| x.to_string()),
+                hash_or_id.map(ToString::to_string),
             ))
         };
 
@@ -178,6 +178,7 @@ impl Slot {
     #[must_use]
     pub fn empty_id(&self) -> Option<&str> {
         match &self.status {
+            #[allow(clippy::match_wildcard_for_single_variants)]
             Status::Empty(EmptyId::Known(known)) => Some(known),
             _ => None,
         }
@@ -185,13 +186,13 @@ impl Slot {
 
     #[must_use]
     pub fn version(&self) -> Option<&Version> {
+        #[allow(clippy::match_wildcard_for_single_variants)]
         match &self.status {
             Status::Used(version) => Some(version),
             _ => None,
         }
     }
 
-    #[must_use]
     pub(crate) fn into_version(self, version: Version) -> Result<Self> {
         ensure!(!self.is_used(), "Can't assign version to already used slot");
         Ok(Self {

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -258,18 +258,10 @@ impl Slot {
 mod tests {
     use super::*;
 
-    fn volume(name: &str) -> Volume {
-        Volume {
-            lv_name: name.to_string(),
-            vg_name: "vg".into(),
-            lv_attr: None,
-            lv_size_bytes: None,
-        }
-    }
-
     #[test]
     fn parse_used_root_with_hash() {
-        let (slots, unparsed) = Slot::from_volumes(vec![volume("root_1.2.3_deadbeefdeadbeef")]);
+        let (slots, unparsed) =
+            Slot::from_volumes(vec![Volume::new("root_1.2.3_deadbeefdeadbeef")]);
         assert_eq!(slots.len(), 1);
         assert!(unparsed.is_empty());
 
@@ -287,7 +279,7 @@ mod tests {
 
     #[test]
     fn parse_used_verity_without_hash_is_legacy() {
-        let (slots, unparsed) = Slot::from_volumes(vec![volume("verity_0")]);
+        let (slots, unparsed) = Slot::from_volumes(vec![Volume::new("verity_0")]);
         assert_eq!(slots.len(), 1);
         assert!(unparsed.is_empty());
 
@@ -301,7 +293,7 @@ mod tests {
 
     #[test]
     fn parse_empty_with_known_id() {
-        let (slots, unparsed) = Slot::from_volumes(vec![volume("root_empty_3")]);
+        let (slots, unparsed) = Slot::from_volumes(vec![Volume::new("root_empty_3")]);
         assert_eq!(slots.len(), 1);
         assert!(unparsed.is_empty());
 
@@ -315,7 +307,7 @@ mod tests {
 
     #[test]
     fn parse_empty_legacy() {
-        let (slots, unparsed) = Slot::from_volumes(vec![volume("verity_empty")]);
+        let (slots, unparsed) = Slot::from_volumes(vec![Volume::new("verity_empty")]);
         assert_eq!(slots.len(), 1);
         assert!(unparsed.is_empty());
 
@@ -331,7 +323,7 @@ mod tests {
     #[test]
     fn slot_display_roundtrip_used() {
         let original = "root_1.2.3_deadbeefdeadbeef";
-        let (slots, _) = Slot::from_volumes(vec![volume(original)]);
+        let (slots, _) = Slot::from_volumes(vec![Volume::new(original)]);
 
         let rendered = slots[0].to_string();
         assert_eq!(rendered, original);
@@ -340,7 +332,7 @@ mod tests {
     #[test]
     fn slot_display_roundtrip_empty_known() {
         let original = "verity_empty_7";
-        let (slots, _) = Slot::from_volumes(vec![volume(original)]);
+        let (slots, _) = Slot::from_volumes(vec![Volume::new(original)]);
 
         let rendered = slots[0].to_string();
         assert_eq!(rendered, original);
@@ -349,7 +341,7 @@ mod tests {
     #[test]
     fn slot_display_roundtrip_empty_legacy() {
         let original = "root_empty";
-        let (slots, _) = Slot::from_volumes(vec![volume(original)]);
+        let (slots, _) = Slot::from_volumes(vec![Volume::new(original)]);
 
         let rendered = slots[0].to_string();
         assert_eq!(rendered, original);
@@ -359,7 +351,7 @@ mod tests {
 
     #[test]
     fn cannot_assign_version_to_used_slot() {
-        let (slots, _) = Slot::from_volumes(vec![volume("root_1.0.0_deadbeef")]);
+        let (slots, _) = Slot::from_volumes(vec![Volume::new("root_1.0.0_deadbeef")]);
 
         let slot = slots.into_iter().next().unwrap();
         let new_version = Version::new("2.0.0".into(), Some("cafebabe".into()));
@@ -369,7 +361,7 @@ mod tests {
 
     #[test]
     fn can_assign_version_to_empty_slot() {
-        let (slots, _) = Slot::from_volumes(vec![volume("root_empty_1")]);
+        let (slots, _) = Slot::from_volumes(vec![Volume::new("root_empty_1")]);
 
         let slot = slots.into_iter().next().unwrap();
         let new_version = Version::new("1.0.0".into(), Some("deadbeef".into()));
@@ -380,9 +372,9 @@ mod tests {
     #[test]
     fn swap_volume_goes_to_unparsed() {
         let vols = vec![
-            volume("root_1.2.3_deadbeef"),
-            volume("swap"),
-            volume("verity_empty_0"),
+            Volume::new("root_1.2.3_deadbeef"),
+            Volume::new("swap"),
+            Volume::new("verity_empty_0"),
         ];
 
         let (slots, unparsed) = Slot::from_volumes(vols);

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -14,6 +14,21 @@ pub struct Slot {
     pub hash: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotClass {
+    /// Slot is structurally invalid
+    Broken,
+
+    /// Slot is currently active (booted)
+    Active,
+
+    /// Slot is valid but empty (no version)
+    Empty,
+
+    /// Slot is valid, installed, but not active
+    Inactive,
+}
+
 impl TryFrom<&str> for Slot {
     type Error = anyhow::Error;
 

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -1,7 +1,7 @@
 use super::Version;
 use super::lvm::Volume;
 use super::pipeline::{CommandSpec, Pipeline};
-use anyhow::{Context, Result, anyhow, ensure};
+use anyhow::{Result, anyhow, ensure};
 use std::fmt;
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/crates/ota-update/src/image/slot.rs
+++ b/crates/ota-update/src/image/slot.rs
@@ -1,0 +1,140 @@
+use anyhow::{Context, Result, anyhow};
+use std::convert::TryFrom;
+
+#[derive(Debug, PartialEq)]
+pub struct Slot {
+    pub name: String,
+    pub version: Option<String>,
+    pub hash: Option<String>,
+}
+
+impl TryFrom<&str> for Slot {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        // split from the right: [name]_[version]_[hash?]
+        let mut parts = value.rsplitn(3, '_');
+
+        let last = parts.next().ok_or_else(|| anyhow!("empty input"))?;
+        let middle = parts.next().ok_or_else(|| anyhow!("missing version"))?;
+        let first = parts.next();
+
+        let (name, version_raw, hash) = match first {
+            Some(name) => (name, middle, Some(last)),
+            None => (middle, last, None),
+        };
+
+        if name.is_empty() {
+            return Err(anyhow!("name is empty"));
+        }
+
+        let version = if version_raw == "empty" {
+            None
+        } else {
+            Some(version_raw.to_string())
+        };
+
+        Ok(Slot {
+            name: name.to_string(),
+            version,
+            hash: hash.map(|h| h.to_string()),
+        })
+    }
+}
+
+impl std::fmt::Display for Slot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let version = self.version.as_deref().unwrap_or("empty");
+        write!(f, "{}_{version}", self.name);
+        if let Some(hash) = &self.hash {
+            write!(f, "_{}", hash)?;
+        }
+        Ok(())
+    }
+}
+
+impl Slot {
+    fn is_empty(&self) -> bool {
+        self.version.is_none()
+    }
+
+    fn is_sibling(&self, other: &Self) -> bool {
+        self.name != other.name && self.version == other.version && self.hash == other.hash
+    }
+
+    // For UI/introspection
+    fn version_id(&self) -> Option<String> {
+        match &self.hash {
+            Some(h) => self.version.as_deref().map(|v| format!("{v}-{h}")),
+            None => self.version.clone(),
+        }
+    }
+
+    /// Generate shell command for renaming slot
+    fn rename(&self, other: &Self) -> String {
+        format!("lvrename {self} {other}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_slot() {
+        let s = Slot::try_from("name_1.2.3_abcde").unwrap();
+        assert_eq!(s.name, "name");
+        assert_eq!(s.version.as_deref(), Some("1.2.3"));
+        assert_eq!(s.hash.as_deref(), Some("abcde"));
+    }
+
+    #[test]
+    fn parse_without_hash() {
+        let s = Slot::try_from("name_1.2.3").unwrap();
+        assert_eq!(s.name, "name");
+        assert_eq!(s.version.as_deref(), Some("1.2.3"));
+        assert!(s.hash.is_none());
+    }
+
+    #[test]
+    fn parse_empty_version() {
+        let s = Slot::try_from("name_empty").unwrap();
+        assert_eq!(s.name, "name");
+        assert!(s.version.is_none());
+        assert!(s.hash.is_none());
+    }
+
+    #[test]
+    fn parse_empty_version_with_hash() {
+        let s = Slot::try_from("name_empty_deadbeef").unwrap();
+        assert_eq!(s.name, "name");
+        assert!(s.version.is_none());
+        assert_eq!(s.hash.as_deref(), Some("deadbeef"));
+    }
+
+    #[test]
+    fn display_roundtrip() {
+        let inputs = [
+            "name_1.2.3_abcde",
+            "name_1.2.3",
+            "name_empty",
+            "name_empty_deadbeef",
+        ];
+
+        for input in inputs {
+            let slot = Slot::try_from(input).unwrap();
+            let rendered = slot.to_string();
+            let reparsed = Slot::try_from(rendered.as_str()).unwrap();
+
+            assert_eq!(slot.name, reparsed.name);
+            assert_eq!(slot.version, reparsed.version);
+            assert_eq!(slot.hash, reparsed.hash);
+        }
+    }
+
+    #[test]
+    fn invalid_format_fails() {
+        assert!(Slot::try_from("").is_err());
+        assert!(Slot::try_from("_1.2.3").is_err());
+    }
+}

--- a/crates/ota-update/src/image/test/data.rs
+++ b/crates/ota-update/src/image/test/data.rs
@@ -1,0 +1,112 @@
+// Expected parameters in /proc/cmdline with some unrelated params (`root=fstab`)
+pub const KERNEL_CMDLINE: &str = "ghav.revision=25.12.1 storehash=deadbeefcafebabe root=fstab";
+
+// Captured by `sudo lvs --all --nameprefixes --noheadings` from prototype Ghaf with A/B update placeholder slots
+pub const LVS: &str = r#"
+  LVM2_LV_NAME='persist' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='<829.38g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='root_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='root_empty' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='swap' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='12.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='verity_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='verity_empty' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+"#;
+
+pub const LVS_INSTALLED: &str = r#"
+  LVM2_LV_NAME='persist' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='<829.38g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='root_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='root_25.12.1_deadbeefdeadbeef' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='swap' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='12.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='verity_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  LVM2_LV_NAME='verity_25.12.1_deadbeefdeadbeef' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+"#;
+
+// Captured by `bootctl list --json=pretty` on Lenovo Carbon X1 gen11 with Ghaf with one debug image, addition UKI kernel,
+// and regular NixOS boot media plugged in.
+pub const BOOTCTL: &str = r#"
+[
+        {
+                "type" : "type2",
+                "source" : "esp",
+                "id" : "nixos_25.12.1.efi",
+                "path" : "/boot/EFI/Linux/nixos_25.12.1+2-1.efi",
+                "root" : "/boot",
+                "title" : "NixOS 25.11 (Xantusia)",
+                "showTitle" : "NixOS 25.11 (Xantusia)",
+                "sortKey" : "nixos",
+                "version" : "25.11 (Xantusia)",
+                "options" : "init=/nix/store/c6gcy5zhgfpgp0n5gwixpp282nmdf240-nixos-system-ghaf-host-25.11.20251110.150b905/init audit_backlog_limit=8192 usbcore.quirks=2357:0601:k,0bda:8153:k console=tty0 console=ttyUSB0,115200 drm.panic_screen=qr_code intel_iommu=on,sm_on iommu=pt module_blacklist=i915,xe,snd_pcm,bluetooth,btusb acpi_backlight=vendor acpi_osi=linux vfio-pci.ids=8086:51f1,8086:a7a1,8086:519d,8086:51ca,8086:51a3,8086:51a4 storehash=3da5ea13e714f917cc9588038dd4ba3f0c12bb32403529a7ae3daee7dcfd8ffc systemd.verity_root_options=panic-on-corruption systemd.setenv=SYSTEMD_SULOGIN_FORCE=1 root=fstab loglevel=4 lsm=landlock,yama,bpf audit=1 audit_backlog_limit=8192",
+                "linux" : "/EFI/Linux/nixos_25.12.1+2-1.efi",
+                "isReported" : false,
+                "triesLeft" : 2,
+                "triesDone" : 1,
+                "isDefault" : false,
+                "isSelected" : false,
+                "addons" : null,
+                "cmdline" : "init=/nix/store/c6gcy5zhgfpgp0n5gwixpp282nmdf240-nixos-system-ghaf-host-25.11.20251110.150b905/init audit_backlog_limit=8192 usbcore.quirks=2357:0601:k,0bda:8153:k console=tty0 console=ttyUSB0,115200 drm.panic_screen=qr_code intel_iommu=on,sm_on iommu=pt module_blacklist=i915,xe,snd_pcm,bluetooth,btusb acpi_backlight=vendor acpi_osi=linux vfio-pci.ids=8086:51f1,8086:a7a1,8086:519d,8086:51ca,8086:51a3,8086:51a4 storehash=3da5ea13e714f917cc9588038dd4ba3f0c12bb32403529a7ae3daee7dcfd8ffc systemd.verity_root_options=panic-on-corruption systemd.setenv=SYSTEMD_SULOGIN_FORCE=1 root=fstab loglevel=4 lsm=landlock,yama,bpf audit=1 audit_backlog_limit=8192"
+        },
+        {
+                "type" : "type1",
+                "source" : "esp",
+                "id" : "nixos-generation-1.conf",
+                "path" : "/boot/loader/entries/nixos-generation-1.conf",
+                "root" : "/boot",
+                "title" : "NixOS",
+                "showTitle" : "NixOS",
+                "sortKey" : "nixos",
+                "version" : "Generation 1 NixOS Xantusia 25.11.20251110.150b905 (Linux 6.17.7), built on 2025-12-07",
+                "options" : "init=/nix/store/b7x7spfpgpjdiafqyd7avqwgzamffsi8-nixos-system-ghaf-host-25.11.20251110.150b905/init usbcore.quirks=2357:0601:k,0bda:8153:k console=tty0 console=ttyUSB0,115200 drm.panic_screen=qr_code intel_iommu=on,sm_on iommu=pt module_blacklist=i915,xe,snd_pcm,bluetooth,btusb acpi_backlight=vendor acpi_osi=linux vfio-pci.ids=8086:51f1,8086:a7a1,8086:519d,8086:51ca,8086:51a3,8086:51a4 root=fstab loglevel=4 lsm=landlock,yama,bpf",
+                "linux" : "/EFI/nixos/s0g4x6zc46xcpwym5166a8xrb1443gfj-linux-6.17.7-bzImage.efi",
+                "initrd" : [
+                        "/EFI/nixos/fvfycdrh9af21vd0wv2nvir4yzjy30hd-initrd-linux-6.17.7-initrd.efi"
+                ],
+                "isReported" : true,
+                "isDefault" : true,
+                "isSelected" : true,
+                "addons" : null,
+                "cmdline" : "init=/nix/store/b7x7spfpgpjdiafqyd7avqwgzamffsi8-nixos-system-ghaf-host-25.11.20251110.150b905/init usbcore.quirks=2357:0601:k,0bda:8153:k console=tty0 console=ttyUSB0,115200 drm.panic_screen=qr_code intel_iommu=on,sm_on iommu=pt module_blacklist=i915,xe,snd_pcm,bluetooth,btusb acpi_backlight=vendor acpi_osi=linux vfio-pci.ids=8086:51f1,8086:a7a1,8086:519d,8086:51ca,8086:51a3,8086:51a4 root=fstab loglevel=4 lsm=landlock,yama,bpf"
+        },
+        {
+                "type" : "loader",
+                "source" : "esp",
+                "id" : "nixos_25.12.1+2-1.efi",
+                "path" : "/sys/firmware/efi/efivars/LoaderEntries-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f",
+                "showTitle" : "nixos_25.12.1+2-1.efi",
+                "isReported" : true,
+                "isDefault" : false,
+                "isSelected" : false,
+                "addons" : null
+        },
+        {
+                "type" : "auto",
+                "source" : "esp",
+                "id" : "auto-reboot-to-firmware-setup",
+                "path" : "/sys/firmware/efi/efivars/LoaderEntries-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f",
+                "title" : "Reboot Into Firmware Interface",
+                "showTitle" : "Reboot Into Firmware Interface",
+                "isReported" : true,
+                "isDefault" : false,
+                "isSelected" : false,
+                "addons" : null
+        }
+]
+"#;
+
+pub const MANIFEST: &str = r#"
+{
+ "meta": {},
+ "version": "25.12.1",
+ "root_verity_hash": "44cc41b403a2d323a68f42941131169899545eaceebe332e24426e9ff7d7f3bc",
+ "root": {
+  "file": "ghaf_root_25.12.1_44cc41b403a2d323.raw.zst",
+  "sha256": "fixme"
+ },
+ "verity": {
+  "file": "ghaf_verity_25.12.1_44cc41b403a2d323.raw.zst",
+  "sha256": "fixme"
+ },
+ "kernel": {
+  "file": "ghaf_kernel_25.12.1_44cc41b403a2d323.efi",
+  "sha256": "fixme"
+ }
+}
+"#;

--- a/crates/ota-update/src/image/test/data.rs
+++ b/crates/ota-update/src/image/test/data.rs
@@ -1,5 +1,5 @@
 // Expected parameters in /proc/cmdline with some unrelated params (`root=fstab`)
-pub const KERNEL_CMDLINE: &str = "ghaf.revision=25.12.1 storehash=deadbeefcafebabe root=fstab";
+pub const KERNEL_CMDLINE: &str = "ghaf.revision=25.12.1 storehash=deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe root=fstab";
 
 // Captured by `LC_NUMERIC=C  lvs --all --report-format json --units B` from prototype Ghaf with A/B update placeholder slots
 pub const LVS: &str = r#"

--- a/crates/ota-update/src/image/test/data.rs
+++ b/crates/ota-update/src/image/test/data.rs
@@ -1,23 +1,45 @@
 // Expected parameters in /proc/cmdline with some unrelated params (`root=fstab`)
 pub const KERNEL_CMDLINE: &str = "ghaf.revision=25.12.1 storehash=deadbeefcafebabe root=fstab";
 
-// Captured by `sudo lvs --all --nameprefixes --noheadings` from prototype Ghaf with A/B update placeholder slots
+// Captured by `LC_NUMERIC=C  lvs --all --report-format json --units B` from prototype Ghaf with A/B update placeholder slots
 pub const LVS: &str = r#"
-  LVM2_LV_NAME='persist' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='<829.38g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='root_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='root_empty' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='swap' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='12.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='verity_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='verity_empty' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  {
+      "report": [
+          {
+              "lv": [
+                  {"lv_name":"persist", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"890538819584", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"root_0", "vg_name":"pool", "lv_attr":"-wi-a-----", "lv_size":"53687091200", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"root_empty", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"53687091200", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"swap", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"12884901888", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"verity_0", "vg_name":"pool", "lv_attr":"-wi-a-----", "lv_size":"6442450944", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"verity_empty", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"6442450944", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""}
+              ]
+          }
+      ]
+      ,
+      "log": [
+      ]
+  }
 "#;
 
 pub const LVS_INSTALLED: &str = r#"
-  LVM2_LV_NAME='persist' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='<829.38g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='root_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='root_25.12.1_deadbeefdeadbeef' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='50.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='swap' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-ao----' LVM2_LV_SIZE='12.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='verity_0' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
-  LVM2_LV_NAME='verity_25.12.1_deadbeefdeadbeef' LVM2_VG_NAME='pool' LVM2_LV_ATTR='-wi-a-----' LVM2_LV_SIZE='6.00g' LVM2_POOL_LV='' LVM2_ORIGIN='' LVM2_DATA_PERCENT='' LVM2_METADATA_PERCENT='' LVM2_MOVE_PV='' LVM2_MIRROR_LOG='' LVM2_COPY_PERCENT='' LVM2_CONVERT_LV=''
+  {
+      "report": [
+          {
+              "lv": [
+                  {"lv_name":"persist", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"890538819584", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"root_0", "vg_name":"pool", "lv_attr":"-wi-a-----", "lv_size":"53687091200", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"root_25.12.1_deadbeefdeadbeef", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"53687091200B", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"swap", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"12884901888", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"verity_0", "vg_name":"pool", "lv_attr":"-wi-a-----", "lv_size":"6442450944", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""},
+                  {"lv_name":"verity_25.12.1_deadbeefdeadbeef", "vg_name":"pool", "lv_attr":"-wi-ao----", "lv_size":"6442450944", "pool_lv":"", "origin":"", "data_percent":"", "metadata_percent":"", "move_pv":"", "mirror_log":"", "copy_percent":"", "convert_lv":""}
+              ]
+          }
+      ]
+      ,
+      "log": [
+      ]
+  }
 "#;
 
 // Captured by `bootctl list --json=pretty` on Lenovo Carbon X1 gen11 with Ghaf with one debug image, addition UKI kernel,

--- a/crates/ota-update/src/image/test/data.rs
+++ b/crates/ota-update/src/image/test/data.rs
@@ -1,5 +1,5 @@
 // Expected parameters in /proc/cmdline with some unrelated params (`root=fstab`)
-pub const KERNEL_CMDLINE: &str = "ghav.revision=25.12.1 storehash=deadbeefcafebabe root=fstab";
+pub const KERNEL_CMDLINE: &str = "ghaf.revision=25.12.1 storehash=deadbeefcafebabe root=fstab";
 
 // Captured by `sudo lvs --all --nameprefixes --noheadings` from prototype Ghaf with A/B update placeholder slots
 pub const LVS: &str = r#"
@@ -27,8 +27,8 @@ pub const BOOTCTL: &str = r#"
         {
                 "type" : "type2",
                 "source" : "esp",
-                "id" : "nixos_25.12.1.efi",
-                "path" : "/boot/EFI/Linux/nixos_25.12.1+2-1.efi",
+                "id" : "ghaf-25.12.1-deadbeefdeadbeef.efi",
+                "path" : "/boot/EFI/Linux/ghaf-25.12.1-deadbeefdeadbeef+2-1.efi",
                 "root" : "/boot",
                 "title" : "NixOS 25.11 (Xantusia)",
                 "showTitle" : "NixOS 25.11 (Xantusia)",

--- a/crates/ota-update/src/image/test/helpers.rs
+++ b/crates/ota-update/src/image/test/helpers.rs
@@ -4,7 +4,7 @@ use crate::image::manifest::{File, Manifest};
 use crate::image::slot::Slot;
 
 pub fn slots(names: &[&str]) -> Vec<Slot> {
-    let vols: Vec<_> = names.iter().map(|n| Volume::new(n)).collect();
+    let vols = names.iter().map(|n| Volume::new(n));
     let (slots, _unparsed) = Slot::from_volumes(vols);
     slots
 }
@@ -30,7 +30,7 @@ pub fn manifest(version: &str, hash: &str) -> Manifest {
 }
 
 pub fn groups(names: &[&str]) -> Vec<SlotGroup> {
-    let vols: Vec<_> = names.iter().map(|n| Volume::new(n)).collect();
+    let vols = names.iter().map(|n| Volume::new(n));
     let (slots, _unparsed) = Slot::from_volumes(vols);
     SlotGroup::group_volumes(slots, Vec::new()).unwrap()
 }

--- a/crates/ota-update/src/image/test/helpers.rs
+++ b/crates/ota-update/src/image/test/helpers.rs
@@ -1,0 +1,38 @@
+use crate::image::lvm::Volume;
+use crate::image::manifest::{File, Manifest};
+use crate::image::slot::Slot;
+
+pub fn volume(name: &str) -> Volume {
+    Volume {
+        lv_name: name.to_string(),
+        vg_name: "vg".into(),
+        lv_attr: None,
+        lv_size_bytes: None,
+    }
+}
+
+pub fn slots(names: &[&str]) -> Vec<Slot> {
+    let vols: Vec<_> = names.iter().map(|n| volume(n)).collect();
+    let (slots, _unparsed) = Slot::from_volumes(vols);
+    slots
+}
+
+pub fn manifest(version: &str, hash: &str) -> Manifest {
+    Manifest {
+        meta: Default::default(),
+        version: version.into(),
+        root_verity_hash: hash.into(),
+        kernel: File {
+            name: "k".into(),
+            sha256sum: "x".into(),
+        },
+        store: File {
+            name: "s".into(),
+            sha256sum: "x".into(),
+        },
+        verity: File {
+            name: "v".into(),
+            sha256sum: "x".into(),
+        },
+    }
+}

--- a/crates/ota-update/src/image/test/helpers.rs
+++ b/crates/ota-update/src/image/test/helpers.rs
@@ -3,17 +3,8 @@ use crate::image::lvm::Volume;
 use crate::image::manifest::{File, Manifest};
 use crate::image::slot::Slot;
 
-pub fn volume(name: &str) -> Volume {
-    Volume {
-        lv_name: name.to_string(),
-        vg_name: "vg".into(),
-        lv_attr: None,
-        lv_size_bytes: None,
-    }
-}
-
 pub fn slots(names: &[&str]) -> Vec<Slot> {
-    let vols: Vec<_> = names.iter().map(|n| volume(n)).collect();
+    let vols: Vec<_> = names.iter().map(|n| Volume::new(n)).collect();
     let (slots, _unparsed) = Slot::from_volumes(vols);
     slots
 }
@@ -39,7 +30,7 @@ pub fn manifest(version: &str, hash: &str) -> Manifest {
 }
 
 pub fn groups(names: &[&str]) -> Vec<SlotGroup> {
-    let vols: Vec<_> = names.iter().map(|n| volume(n)).collect();
+    let vols: Vec<_> = names.iter().map(|n| Volume::new(n)).collect();
     let (slots, _unparsed) = Slot::from_volumes(vols);
     SlotGroup::group_volumes(slots, Vec::new()).unwrap()
 }

--- a/crates/ota-update/src/image/test/helpers.rs
+++ b/crates/ota-update/src/image/test/helpers.rs
@@ -1,3 +1,4 @@
+use crate::image::group::SlotGroup;
 use crate::image::lvm::Volume;
 use crate::image::manifest::{File, Manifest};
 use crate::image::slot::Slot;
@@ -35,4 +36,10 @@ pub fn manifest(version: &str, hash: &str) -> Manifest {
             sha256sum: "x".into(),
         },
     }
+}
+
+pub fn groups(names: &[&str]) -> Vec<SlotGroup> {
+    let vols: Vec<_> = names.iter().map(|n| volume(n)).collect();
+    let (slots, _unparsed) = Slot::from_volumes(vols);
+    SlotGroup::group_volumes(slots, Vec::new()).unwrap()
 }

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -2,20 +2,23 @@ mod data;
 mod helpers;
 
 use crate::bootctl::parse_bootctl;
+use crate::image::lvm::parse_lvs_json;
 use crate::image::manifest::Manifest;
 use crate::image::runtime::Runtime;
 use data::{BOOTCTL, KERNEL_CMDLINE, LVS, LVS_INSTALLED, MANIFEST};
 
-pub use helpers::{groups, manifest, slots, volume};
+pub use helpers::{groups, manifest, slots};
 
 pub fn make_test_runtime() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS, "root=fstab", bootctl).unwrap()
+    let volumes = parse_lvs_json(&LVS).unwrap();
+    Runtime::new(volumes, "root=fstab", bootctl).unwrap()
 }
 
 pub fn make_test_runtime_installed() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, bootctl).unwrap()
+    let volumes = parse_lvs_json(&LVS_INSTALLED).unwrap();
+    Runtime::new(volumes, &KERNEL_CMDLINE, bootctl).unwrap()
 }
 
 pub fn make_test_manifest() -> Manifest {

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -10,12 +10,12 @@ pub use helpers::{manifest, slots, volume};
 
 pub fn make_test_runtime() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS, "root=fstab", &bootctl).unwrap()
+    Runtime::new(&LVS, "root=fstab", bootctl).unwrap()
 }
 
 pub fn make_test_runtime_installed() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, &bootctl).unwrap()
+    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, bootctl).unwrap()
 }
 
 pub fn make_test_manifest() -> Manifest {

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -1,0 +1,20 @@
+mod data;
+
+use crate::bootctl::parse_bootctl;
+use crate::image::manifest::Manifest;
+use crate::image::runtime::Runtime;
+use data::{BOOTCTL, KERNEL_CMDLINE, LVS, LVS_INSTALLED, MANIFEST};
+
+pub fn make_test_runtime() -> Runtime {
+    let bootctl = parse_bootctl(&BOOTCTL).unwrap();
+    Runtime::new(&LVS, "root=fstab", &bootctl)
+}
+
+pub fn make_test_runtime_installed() -> Runtime {
+    let bootctl = parse_bootctl(&BOOTCTL).unwrap();
+    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, &bootctl)
+}
+
+pub fn make_test_manifest() -> Manifest {
+    serde_json::from_str(&MANIFEST).unwrap()
+}

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -6,7 +6,7 @@ use crate::image::manifest::Manifest;
 use crate::image::runtime::Runtime;
 use data::{BOOTCTL, KERNEL_CMDLINE, LVS, LVS_INSTALLED, MANIFEST};
 
-pub use helpers::{manifest, slots, volume};
+pub use helpers::{groups, manifest, slots, volume};
 
 pub fn make_test_runtime() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -10,12 +10,12 @@ pub use helpers::{manifest, slots, volume};
 
 pub fn make_test_runtime() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS, "root=fstab", &bootctl)
+    Runtime::new(&LVS, "root=fstab", &bootctl).unwrap()
 }
 
 pub fn make_test_runtime_installed() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();
-    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, &bootctl)
+    Runtime::new(&LVS_INSTALLED, &KERNEL_CMDLINE, &bootctl).unwrap()
 }
 
 pub fn make_test_manifest() -> Manifest {

--- a/crates/ota-update/src/image/test/mod.rs
+++ b/crates/ota-update/src/image/test/mod.rs
@@ -1,9 +1,12 @@
 mod data;
+mod helpers;
 
 use crate::bootctl::parse_bootctl;
 use crate::image::manifest::Manifest;
 use crate::image::runtime::Runtime;
 use data::{BOOTCTL, KERNEL_CMDLINE, LVS, LVS_INSTALLED, MANIFEST};
+
+pub use helpers::{manifest, slots, volume};
 
 pub fn make_test_runtime() -> Runtime {
     let bootctl = parse_bootctl(&BOOTCTL).unwrap();

--- a/crates/ota-update/src/image/uki.rs
+++ b/crates/ota-update/src/image/uki.rs
@@ -1,0 +1,186 @@
+use crate::bootctl::BootctlItem;
+use anyhow::{Result, anyhow, bail};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UkiEntry {
+    /// Slot identity
+    pub version: String,
+    pub hash: String,
+
+    /// Boot loader counters parsed from filename
+    pub boot_counter: Option<BootCounter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootCounter {
+    pub remaining: u32,
+    pub used: Option<u32>,
+}
+
+impl fmt::Display for UkiEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ghaf-{}-{}", self.version, self.hash)?;
+
+        if let Some(counter) = &self.boot_counter {
+            write!(f, "+{}", counter.remaining)?;
+            if let Some(used) = counter.used {
+                write!(f, "-{}", used)?;
+            }
+        }
+
+        write!(f, ".efi")
+    }
+}
+
+impl TryFrom<&str> for UkiEntry {
+    type Error = anyhow::Error;
+
+    fn try_from(name: &str) -> Result<Self> {
+        if !name.ends_with(".efi") {
+            bail!("not an EFI binary");
+        }
+
+        let stem = name.trim_end_matches(".efi");
+
+        let stem = stem
+            .strip_prefix("ghaf-")
+            .ok_or_else(|| anyhow!("invalid UKI prefix"))?;
+
+        // Parse optional boot counters from the end: +N or +N-M
+        let (core, boot_counter) = if let Some((left, right)) = stem.rsplit_once('+') {
+            let (remaining, used) = match right.split_once('-') {
+                Some((r, u)) => (
+                    r.parse::<u32>()
+                        .map_err(|_| anyhow!("invalid remaining counter"))?,
+                    Some(
+                        u.parse::<u32>()
+                            .map_err(|_| anyhow!("invalid used counter"))?,
+                    ),
+                ),
+                None => (
+                    right
+                        .parse::<u32>()
+                        .map_err(|_| anyhow!("invalid remaining counter"))?,
+                    None,
+                ),
+            };
+
+            (left, Some(BootCounter { remaining, used }))
+        } else {
+            (stem, None)
+        };
+
+        let (version, hash) = core
+            .split_once('-')
+            .ok_or_else(|| anyhow!("missing version/hash"))?;
+
+        if version == "empty" {
+            bail!("UKI version must not be empty");
+        }
+
+        Ok(UkiEntry {
+            version: version.to_string(),
+            hash: hash.to_string(),
+            boot_counter,
+        })
+    }
+}
+
+impl UkiEntry {
+    pub fn from_bootctl(bootctl: &Vec<BootctlItem>) -> Vec<Self> {
+        bootctl
+            .iter()
+            .filter_map(|each| {
+                if each.r#type == "type2" {
+                    // Invalid entries just skipped
+                    each.path
+                        .file_name()
+                        .and_then(|x| x.to_str())
+                        .and_then(|x| UkiEntry::try_from(x).ok())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn full_name<P: AsRef<Path>>(&self, base_dir: P) -> PathBuf {
+        base_dir.as_ref().join(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_uki() {
+        let uki = UkiEntry::try_from("ghaf-1.2.3-deadbeefdeadbeef.efi").unwrap();
+        assert_eq!(uki.version, "1.2.3");
+        assert_eq!(uki.hash, "deadbeefdeadbeef");
+        assert!(uki.boot_counter.is_none());
+    }
+
+    #[test]
+    fn parse_uki_with_counters() {
+        let uki = UkiEntry::try_from("ghaf-1.2.3-deadbeefdeadbeef+3-1.efi").unwrap();
+        let c = uki.boot_counter.unwrap();
+        assert_eq!(c.remaining, 3);
+        assert_eq!(c.used, Some(1));
+    }
+
+    #[test]
+    fn reject_empty_version_uki() {
+        assert!(UkiEntry::try_from("ghaf-empty-deadbeefdeadbeef.efi").is_err());
+    }
+
+    #[test]
+    fn reject_non_efi_file() {
+        assert!(UkiEntry::try_from("ghaf-1.2.3-deadbeefdeadbeef").is_err());
+    }
+
+    #[test]
+    fn uki_roundtrip_parse_display_parse() {
+        let original = "ghaf-1.2.3-deadbeefdeadbeef+3-1.efi";
+
+        let parsed = UkiEntry::try_from(original).unwrap();
+        let rendered = parsed.to_string();
+        let reparsed = UkiEntry::try_from(rendered.as_str()).unwrap();
+
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn uki_roundtrip_display_parse_display() {
+        let uki = UkiEntry {
+            version: "1.2.3".into(),
+            hash: "deadbeefdeadbeef".into(),
+            boot_counter: Some(BootCounter {
+                remaining: 5,
+                used: None,
+            }),
+        };
+
+        let name = uki.to_string();
+        let parsed = UkiEntry::try_from(name.as_str()).unwrap();
+
+        assert_eq!(uki, parsed);
+    }
+
+    #[test]
+    fn uki_roundtrip_without_counters() {
+        let uki = UkiEntry {
+            version: "2.0.0".into(),
+            hash: "aaaaaaaaaaaaaaaa".into(),
+            boot_counter: None,
+        };
+
+        let name = uki.to_string();
+        assert_eq!(name, "ghaf-2.0.0-aaaaaaaaaaaaaaaa.efi");
+
+        let parsed = UkiEntry::try_from(name.as_str()).unwrap();
+        assert_eq!(uki, parsed);
+    }
+}

--- a/crates/ota-update/src/image/uki.rs
+++ b/crates/ota-update/src/image/uki.rs
@@ -182,10 +182,10 @@ impl BootEntry {
         }
     }
 
-    pub fn to_remove(self) -> Pipeline {
+    pub fn to_remove(&self) -> Pipeline {
         CommandSpec::new("bootctl")
             .arg("unlink")
-            .arg(self.id)
+            .arg(&self.id)
             .into()
     }
 }

--- a/crates/ota-update/src/image/uki.rs
+++ b/crates/ota-update/src/image/uki.rs
@@ -122,8 +122,10 @@ mod tests {
     #[test]
     fn parse_valid_uki() {
         let uki = UkiEntry::try_from("ghaf-1.2.3-deadbeefdeadbeef.efi").unwrap();
-        assert_eq!(uki.version, "1.2.3");
-        assert_eq!(uki.hash, "deadbeefdeadbeef");
+        assert_eq!(
+            uki.version,
+            Version::new("1.2.3".into(), Some("deadbeefdeadbeef".into()))
+        );
         assert!(uki.boot_counter.is_none());
     }
 
@@ -158,9 +160,9 @@ mod tests {
 
     #[test]
     fn uki_roundtrip_display_parse_display() {
+        let version = Version::new("1.2.3".into(), Some("deadbeefdeadbeef".into()));
         let uki = UkiEntry {
-            version: "1.2.3".into(),
-            hash: "deadbeefdeadbeef".into(),
+            version,
             boot_counter: Some(BootCounter {
                 remaining: 5,
                 used: None,
@@ -175,14 +177,14 @@ mod tests {
 
     #[test]
     fn uki_roundtrip_without_counters() {
+        let version = Version::new("2.0.0".into(), Some("deadbeefdeadbeef".into()));
         let uki = UkiEntry {
-            version: "2.0.0".into(),
-            hash: "aaaaaaaaaaaaaaaa".into(),
+            version,
             boot_counter: None,
         };
 
         let name = uki.to_string();
-        assert_eq!(name, "ghaf-2.0.0-aaaaaaaaaaaaaaaa.efi");
+        assert_eq!(name, "ghaf-2.0.0-deadbeefdeadbeef.efi");
 
         let parsed = UkiEntry::try_from(name.as_str()).unwrap();
         assert_eq!(uki, parsed);

--- a/crates/ota-update/src/image/uki.rs
+++ b/crates/ota-update/src/image/uki.rs
@@ -56,6 +56,22 @@ impl fmt::Display for UkiEntry {
     }
 }
 
+impl fmt::Display for BootEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            BootEntryKind::Managed(uki) => {
+                write!(f, "managed: {} [id={}]", uki, self.id)
+            }
+            BootEntryKind::Unmanaged => {
+                write!(f, "unmanaged: id={}", self.id)
+            }
+            BootEntryKind::Legacy => {
+                write!(f, "legacy: id={}", self.id)
+            }
+        }
+    }
+}
+
 impl TryFrom<&str> for UkiEntry {
     type Error = anyhow::Error;
 
@@ -143,6 +159,27 @@ impl BootEntry {
     #[must_use]
     pub fn is_legacy(&self) -> bool {
         matches!(self.kind, BootEntryKind::Legacy)
+    }
+
+    #[must_use]
+    pub fn uki(&self) -> Option<&UkiEntry> {
+        match &self.kind {
+            BootEntryKind::Managed(uki) => Some(&uki),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn version(&self) -> Option<&Version> {
+        self.uki().map(|x| &x.version)
+    }
+
+    #[must_use]
+    pub fn matches(&self, slot: &Slot) -> bool {
+        match &self.kind {
+            BootEntryKind::Managed(uki) => uki.matches(slot),
+            _ => false,
+        }
     }
 
     pub fn to_remove(self) -> Pipeline {

--- a/crates/ota-update/src/image/uki.rs
+++ b/crates/ota-update/src/image/uki.rs
@@ -49,7 +49,7 @@ impl fmt::Display for UkiEntry {
         if let Some(counter) = &self.boot_counter {
             write!(f, "+{}", counter.remaining)?;
             if let Some(used) = counter.used {
-                write!(f, "-{}", used)?;
+                write!(f, "-{used}")?;
             }
         }
 
@@ -113,7 +113,6 @@ impl FromStr for UkiEntry {
 }
 
 impl BootEntry {
-    #[must_use]
     pub fn from_bootctl(items: Vec<BootctlItem>) -> impl Iterator<Item = Self> {
         items.into_iter().filter_map(|item| {
             let id = item.id;
@@ -149,7 +148,7 @@ impl BootEntry {
     #[must_use]
     pub fn uki(&self) -> Option<&UkiEntry> {
         match &self.kind {
-            BootEntryKind::Managed(uki) => Some(&uki),
+            BootEntryKind::Managed(uki) => Some(uki),
             _ => None,
         }
     }
@@ -183,10 +182,12 @@ impl From<UkiEntry> for BootEntry {
 }
 
 impl UkiEntry {
+    #[must_use]
     pub fn full_name<P: AsRef<Path>>(&self, base_dir: P) -> PathBuf {
-        base_dir.as_ref().join(&self.to_string())
+        base_dir.as_ref().join(self.to_string())
     }
 
+    #[must_use]
     pub fn matches(&self, slot: &Slot) -> bool {
         slot.version() == Some(&self.version)
     }

--- a/crates/ota-update/src/image/version.rs
+++ b/crates/ota-update/src/image/version.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Hash)]
+pub struct Version {
+    // FIXME: not pub!
+    pub revision: String,
+    pub hash: Option<String>,
+}
+
+// For visualization purposes, serializers should have explicit formatters
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let version = &self.revision;
+        write!(f, "{version}")?;
+        if let Some(hash) = &self.hash {
+            write!(f, "-{}", hash)?;
+        }
+        Ok(())
+    }
+}
+
+impl Version {
+    pub fn new(revision: String, hash: Option<String>) -> Self {
+        Self { revision, hash }
+    }
+    pub fn as_ref(&self) -> &str {
+        &self.revision
+    }
+    pub fn has_hash(&self) -> bool {
+        self.hash.is_some()
+    }
+    pub fn hash_as_ref(&self) -> Option<&str> {
+        self.hash.as_deref()
+    }
+}

--- a/crates/ota-update/src/image/version.rs
+++ b/crates/ota-update/src/image/version.rs
@@ -20,15 +20,22 @@ impl fmt::Display for Version {
 }
 
 impl Version {
+    #[must_use]
     pub fn new(revision: String, hash: Option<String>) -> Self {
         Self { revision, hash }
     }
+
+    #[must_use]
     pub fn as_ref(&self) -> &str {
         &self.revision
     }
+
+    #[must_use]
     pub fn has_hash(&self) -> bool {
         self.hash.is_some()
     }
+
+    #[must_use]
     pub fn hash_as_ref(&self) -> Option<&str> {
         self.hash.as_deref()
     }

--- a/crates/ota-update/src/image/version.rs
+++ b/crates/ota-update/src/image/version.rs
@@ -13,7 +13,7 @@ impl fmt::Display for Version {
         let version = &self.revision;
         write!(f, "{version}")?;
         if let Some(hash) = &self.hash {
-            write!(f, "-{}", hash)?;
+            write!(f, "-{hash}")?;
         }
         Ok(())
     }
@@ -26,7 +26,7 @@ impl Version {
     }
 
     #[must_use]
-    pub fn as_ref(&self) -> &str {
+    pub fn as_revision(&self) -> &str {
         &self.revision
     }
 

--- a/crates/ota-update/src/lib.rs
+++ b/crates/ota-update/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bootctl;
 pub mod cli;
+pub mod image;
 pub mod profile;
 pub mod query;
 pub mod types;

--- a/nixos/tests/default.nix
+++ b/nixos/tests/default.nix
@@ -7,6 +7,7 @@
     ./dbus.nix
     ./app.nix
     ./ota-update.nix
+    ./ota-update-image.nix
     ./event.nix
   ];
 }

--- a/nixos/tests/ota-update-image.nix
+++ b/nixos/tests/ota-update-image.nix
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Integration test for `ota-update image` (A/B slot-based updates).
+#
+# Exercises the real `ota-update` binary against real LVM volumes, a real
+# UEFI boot chain (OVMF + systemd-boot), and real bootctl — verifying
+# install, status, idempotency, and remove operations end-to-end.
+#
+# The VM boots via systemd-boot on OVMF so that `bootctl set-default`
+# can write real EFI variables, matching production behaviour.
+{ self, ... }:
+{
+  perSystem =
+    { self', pkgs, ... }:
+    {
+      vmTests.tests.ota-update-image = {
+        module = {
+          nodes.machine =
+            { pkgs, lib, ... }:
+            {
+              # Boot through OVMF + systemd-boot so bootctl has real EFI vars
+              virtualisation.useBootLoader = true;
+              virtualisation.useEFIBoot = true;
+              boot.loader.systemd-boot.enable = true;
+              boot.loader.efi.canTouchEfiVariables = true;
+
+              # useBootLoader disables host nix store mounting by default
+              virtualisation.mountHostNixStore = true;
+
+              virtualisation.emptyDiskImages = [ 2048 ];
+              virtualisation.memorySize = 1024;
+
+              environment.systemPackages = [
+                pkgs.efibootmgr
+                pkgs.lvm2
+                pkgs.zstd
+                self'.packages.givc-admin.ota
+              ];
+
+              # LVM volumes mimicking a Ghaf A/B layout:
+              #   root_0 / verity_0          — legacy active slot
+              #   root_empty / verity_empty  — empty B-slot for updates
+              #   swap                       — non-slot volume (ignored)
+              systemd.services.setup-lvm = {
+                description = "Create LVM volumes for OTA update test";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "systemd-udevd.service" ];
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                };
+                path = [
+                  pkgs.lvm2
+                  pkgs.util-linux
+                ];
+                script = ''
+                  set -euo pipefail
+                  disk="/dev/vdb"
+                  for i in $(seq 1 30); do [ -b "$disk" ] && break; sleep 1; done
+
+                  pvcreate -f "$disk"
+                  vgcreate pool "$disk"
+
+                  lvcreate -L 64M -n root_0 pool
+                  lvcreate -L 16M -n verity_0 pool
+                  lvcreate -L 64M -n root_empty pool
+                  lvcreate -L 16M -n verity_empty pool
+                  lvcreate -L 16M -n swap pool
+                '';
+              };
+            };
+
+          testScript =
+            { nodes, ... }:
+            let
+              ota-update = "${self'.packages.givc-admin.ota}/bin/ota-update";
+              version = "25.12.1";
+              verityHash = "44cc41b403a2d323a68f42941131169899545eaceebe332e24426e9ff7d7f3bc";
+              hashFragment = builtins.substring 0 16 verityHash;
+
+              # Fake sysupdate artifacts: tiny zstd-compressed images + dummy UKI + manifest
+              suDir = pkgs.runCommand "fake-sysupdate" { nativeBuildInputs = [ pkgs.zstd ]; } ''
+                mkdir -p $out
+                dd if=/dev/zero of=root.raw bs=4096 count=1
+                dd if=/dev/zero of=verity.raw bs=4096 count=1
+                zstd root.raw -o "$out/ghaf_root_${version}_${hashFragment}.raw.zst"
+                zstd verity.raw -o "$out/ghaf_verity_${version}_${hashFragment}.raw.zst"
+                touch "$out/ghaf_kernel_${version}_${hashFragment}.efi"
+
+                root_sha=$(sha256sum "$out/ghaf_root_${version}_${hashFragment}.raw.zst" | cut -d' ' -f1)
+                verity_sha=$(sha256sum "$out/ghaf_verity_${version}_${hashFragment}.raw.zst" | cut -d' ' -f1)
+                kernel_sha=$(sha256sum "$out/ghaf_kernel_${version}_${hashFragment}.efi" | cut -d' ' -f1)
+
+                cat > "$out/manifest.json" <<EOF
+                {
+                  "meta": {},
+                  "version": "${version}",
+                  "root_verity_hash": "${verityHash}",
+                  "root":   { "file": "ghaf_root_${version}_${hashFragment}.raw.zst",   "sha256": "$root_sha" },
+                  "verity": { "file": "ghaf_verity_${version}_${hashFragment}.raw.zst", "sha256": "$verity_sha" },
+                  "kernel": { "file": "ghaf_kernel_${version}_${hashFragment}.efi",     "sha256": "$kernel_sha" }
+                }
+                EOF
+              '';
+            in
+            ''
+              machine.wait_for_unit("multi-user.target")
+              machine.wait_for_unit("setup-lvm.service")
+
+              with subtest("uefi boot sanity"):
+                  machine.succeed(
+                      "test -e /sys/firmware/efi/efivars/LoaderEntrySelected-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+                  )
+                  machine.succeed("bootctl status")
+
+              with subtest("lvm setup"):
+                  output = machine.succeed("lvs --noheadings -o lv_name pool | sort")
+                  print(f"Initial LVs:\n{output}")
+                  for name in ["root_0", "root_empty", "swap", "verity_0", "verity_empty"]:
+                      assert name in output, f"Expected LV '{name}' not found in: {output}"
+
+              with subtest("boot config before install"):
+                  loader_conf = machine.succeed("cat /boot/loader/loader.conf")
+                  print(f"loader.conf before install:\n{loader_conf}")
+                  assert "@saved" not in loader_conf, "loader.conf should not contain @saved before install"
+                  machine.fail(
+                      "test -e /sys/firmware/efi/efivars/LoaderEntryDefault-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+                  )
+
+              with subtest("status before install"):
+                  status = machine.succeed("${ota-update} image status")
+                  print(f"Status before install:\n{status}")
+                  assert "empty" in status
+
+              with subtest("dry-run install"):
+                  output = machine.succeed("${ota-update} image --dry-run install --manifest ${suDir}/manifest.json")
+                  print(f"Dry-run output:\n{output}")
+                  assert "DRY-RUN" in output
+                  output = machine.succeed("lvs --noheadings -o lv_name pool")
+                  assert "root_empty" in output, "dry-run should not rename volumes"
+
+              with subtest("install"):
+                  machine.succeed("${ota-update} image install --manifest ${suDir}/manifest.json")
+
+                  output = machine.succeed("lvs --noheadings -o lv_name pool | sort")
+                  print(f"LVs after install:\n{output}")
+                  assert "root_${version}_${hashFragment}" in output, f"Expected root slot not found: {output}"
+                  assert "verity_${version}_${hashFragment}" in output, f"Expected verity slot not found: {output}"
+                  assert "root_empty" not in output, f"root_empty should have been renamed: {output}"
+                  assert "verity_empty" not in output, f"verity_empty should have been renamed: {output}"
+
+                  machine.succeed("test -f /boot/EFI/Linux/ghaf-${version}-${hashFragment}.efi")
+
+                  # Legacy bootloader migration: loader.conf updated + EFI var written
+                  machine.succeed("grep -q '@saved' /boot/loader/loader.conf")
+                  machine.succeed(
+                      "test -e /sys/firmware/efi/efivars/LoaderEntryDefault-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+                  )
+
+              with subtest("status after install"):
+                  status = machine.succeed("${ota-update} image status")
+                  print(f"Status after install:\n{status}")
+                  assert "${version}" in status
+
+              with subtest("idempotent install"):
+                  output = machine.succeed("${ota-update} image install --manifest ${suDir}/manifest.json")
+                  print(f"Idempotent install:\n{output}")
+                  assert "Nothing to do" in output
+
+              with subtest("remove"):
+                  machine.succeed("${ota-update} image remove --version ${version} --hash ${hashFragment}")
+
+                  output = machine.succeed("lvs --noheadings -o lv_name pool | sort")
+                  print(f"LVs after remove:\n{output}")
+                  assert "root_${version}_${hashFragment}" not in output, f"root slot should have been removed: {output}"
+                  assert "verity_${version}_${hashFragment}" not in output, f"verity slot should have been removed: {output}"
+                  assert "root_empty" in output, f"Expected root_empty_* after remove: {output}"
+                  assert "verity_empty" in output, f"Expected verity_empty_* after remove: {output}"
+
+              with subtest("status after remove"):
+                  status = machine.succeed("${ota-update} image status")
+                  print(f"Status after remove:\n{status}")
+            '';
+        };
+      };
+    };
+}


### PR DESCRIPTION
The existing unit tests in crates/ota-update cover plan generation and slot selection logic, but cannot exercise the end-to-end flow that involves real LVM operations, real disk I/O via zstdcat|dd, and real EFI variable writes via bootctl.

Boot the test VM through OVMF + systemd-boot so that bootctl set-default can write actual EFI variables, avoiding the need for any stubs or wrappers. Verify the before/after state of both loader.conf and the LoaderEntryDefault EFI variable to prove the legacy bootloader migration path works correctly.